### PR TITLE
Fixes the processor wait implementation based on Dask

### DIFF
--- a/covigator/__init__.py
+++ b/covigator/__init__.py
@@ -1,4 +1,4 @@
-VERSION = "0.4.0.dev4"
+VERSION = "0.4.0.dev5"
 
 MISSENSE_VARIANT = "missense_variant"
 SYNONYMOUS_VARIANT = "synonymous_variant"

--- a/covigator/configuration.py
+++ b/covigator/configuration.py
@@ -42,7 +42,7 @@ class Configuration:
     # dask
     ENV_COVIGATOR_DASK_PORT = "COVIGATOR_DASK_PORT"
 
-    def __init__(self):
+    def __init__(self, verbose=True):
         # local storage
         self.storage_folder = os.getenv(self.ENV_COVIGATOR_STORAGE_FOLDER, "/data/covigator")
         self.content_folder = os.getenv(self.ENV_COVIGATOR_DOWNLOAD_CONTENT_FOLDER)
@@ -89,7 +89,8 @@ class Configuration:
         # NOTE: the defaults are already set in the workflow config
         self.temp_folder = os.getenv(self.ENV_COVIGATOR_TEMP_FOLDER, "/data/covigator-tmp")
 
-        self.log_configuration()
+        if verbose:
+            self.log_configuration()
 
     def log_configuration(self):
         logger.info("Configuration")

--- a/covigator/database/model.py
+++ b/covigator/database/model.py
@@ -72,17 +72,10 @@ class JobStatus(enum.Enum):
 
     PENDING = 1
     QUEUED = 2
-    DOWNLOADED = 3
-    PROCESSED = 4
-    LOADED = 5
-    FAILED_DOWNLOAD = 6
-    FAILED_PROCESSING = 7
-    FAILED_LOAD = 8
-    COOCCURRENCE = 9
-    FAILED_COOCCURRENCE = 10
-    FINISHED = 11
-    HOLD = 12
-    EXCLUDED = 13
+    FAILED_PROCESSING = 3
+    FINISHED = 4
+    HOLD = 5
+    EXCLUDED = 6
 
 
 class DataSource(enum.Enum):

--- a/covigator/database/queries.py
+++ b/covigator/database/queries.py
@@ -47,17 +47,19 @@ class Queries:
         else:
             raise ValueError("Bad data source {}".format(data_source))
 
-    def find_first_pending_job(self, data_source: DataSource) -> Union[JobEna, JobGisaid]:
+    def find_first_pending_jobs(self, data_source: DataSource, n=100) -> List[Union[JobEna, JobGisaid]]:
         if data_source == DataSource.ENA:
             return self.session.query(JobEna) \
                 .filter(JobEna.status == JobStatus.PENDING) \
                 .order_by(JobEna.created_at.desc()) \
-                .first()
+                .limit(n) \
+                .all()
         elif data_source == DataSource.GISAID:
             return self.session.query(JobGisaid) \
                 .filter(JobGisaid.status == JobStatus.PENDING) \
                 .order_by(JobGisaid.created_at.desc()) \
-                .first()
+                .limit(n) \
+                .all()
         else:
             raise ValueError("Bad data source {}".format(data_source))
 

--- a/covigator/database/queries.py
+++ b/covigator/database/queries.py
@@ -65,11 +65,9 @@ class Queries:
 
     def count_jobs_in_queue(self, data_source):
         if data_source == DataSource.ENA:
-            count = self.session.query(JobEna).filter(JobEna.status.in_((
-                JobStatus.QUEUED, JobStatus.DOWNLOADED, JobStatus.PROCESSED, JobStatus.LOADED))).count()
+            count = self.session.query(JobEna).filter(JobEna.status == JobStatus.QUEUED).count()
         elif data_source == DataSource.GISAID:
-            count = self.session.query(JobGisaid).filter(JobGisaid.status.in_((
-                JobStatus.QUEUED, JobStatus.DOWNLOADED, JobStatus.PROCESSED, JobStatus.LOADED))).count()
+            count = self.session.query(JobGisaid).filter(JobGisaid.status == JobStatus.QUEUED).count()
         else:
             raise ValueError("Bad data source {}".format(data_source))
         return count

--- a/covigator/pipeline/downloader.py
+++ b/covigator/pipeline/downloader.py
@@ -46,7 +46,9 @@ class Downloader:
         local_filename = url.split('/')[-1]
         # NOTE: sample folder date/run_accession
         local_folder = os.path.join(
-            self.storage_folder, sample.collection_date.strftime("%Y%m%d"), sample.run_accession)
+            self.storage_folder,
+            sample.collection_date.strftime("%Y%m%d") if sample.collection_date is not None else "nodate",
+            sample.run_accession)
         local_full_path = os.path.join(local_folder, local_filename)
         # avoids downloading the same files over and over
         if not os.path.exists(local_full_path):

--- a/covigator/pipeline/downloader.py
+++ b/covigator/pipeline/downloader.py
@@ -32,19 +32,21 @@ class Downloader:
         md5s = sample_ena.get_fastqs_md5()
         paths = []
         for url, md5 in zip(fastqs, md5s):
-            local_path = self._download_url(sample_ena.run_accession, url, md5)
+            local_path = self._download_url(sample_ena, url, md5)
             paths.append(local_path)
         logger.info("Downloaded {}: {}".format(sample_ena.run_accession, sample_ena.fastq_ftp))
         return SEPARATOR.join(paths)
 
-    def _download_url(self, run_accession, url, md5):
+    def _download_url(self, sample: SampleEna, url, md5):
         """
         This method streams a file (probably large) from a URL and stores it in the local file system
         """
         if not re.match(PROTOCOL_REGEX, url):
             url = FTP_PROTOCOL + url
         local_filename = url.split('/')[-1]
-        local_folder = os.path.join(self.storage_folder, run_accession)
+        # NOTE: sample folder date/run_accession
+        local_folder = os.path.join(
+            self.storage_folder, sample.collection_date.strftime("%Y%m%d"), sample.run_accession)
         local_full_path = os.path.join(local_folder, local_filename)
         # avoids downloading the same files over and over
         if not os.path.exists(local_full_path):

--- a/covigator/pipeline/ena_pipeline.py
+++ b/covigator/pipeline/ena_pipeline.py
@@ -41,7 +41,7 @@ class Pipeline:
                 nextflow=self.config.nextflow,
                 fastq1=fastq1,
                 fastq2="--fastq2 " + fastq2 if fastq2 else "",
-                output_folder=self.config.storage_folder,
+                output_folder=sample_data_folder,
                 name=run_accession,
                 work_folder=self.config.temp_folder,
                 workflow=self.config.workflow,

--- a/covigator/pipeline/gisaid_pipeline.py
+++ b/covigator/pipeline/gisaid_pipeline.py
@@ -22,7 +22,8 @@ class GisaidPipeline:
     def run(self, sample: SampleGisaid):
         logger.info("Processing {}".format(sample.run_accession))
         sample_name = sample.run_accession.replace("/", "_").replace(" ", "-").replace("'", "-").replace("$", "")
-        sample_data_folder = os.path.join(self.config.storage_folder, sample_name)
+        # NOTE: sample folder date/run_accession
+        sample_data_folder = os.path.join(self.config.storage_folder, sample.date.strftime("%Y%m%d"), sample_name)
         output_vcf = os.path.join(
             sample_data_folder,
             "{name}.assembly.normalized.annotated.vcf.gz".format(name=sample_name))

--- a/covigator/pipeline/gisaid_pipeline.py
+++ b/covigator/pipeline/gisaid_pipeline.py
@@ -23,7 +23,9 @@ class GisaidPipeline:
         logger.info("Processing {}".format(sample.run_accession))
         sample_name = sample.run_accession.replace("/", "_").replace(" ", "-").replace("'", "-").replace("$", "")
         # NOTE: sample folder date/run_accession
-        sample_data_folder = os.path.join(self.config.storage_folder, sample.date.strftime("%Y%m%d"), sample_name)
+        sample_data_folder = os.path.join(
+            self.config.storage_folder, sample.date.strftime("%Y%m%d") if sample.date is not None else "nodate",
+            sample_name)
         output_vcf = os.path.join(
             sample_data_folder,
             "{name}.assembly.normalized.annotated.vcf.gz".format(name=sample_name))

--- a/covigator/pipeline/gisaid_pipeline.py
+++ b/covigator/pipeline/gisaid_pipeline.py
@@ -54,7 +54,7 @@ class GisaidPipeline:
                       "-profile conda -offline -work-dir {work_folder} -with-trace {trace_file}".format(
                 nextflow=self.config.nextflow,
                 fasta=input_fasta,
-                output_folder=self.config.storage_folder,
+                output_folder=sample_data_folder,
                 name=sample_name,
                 work_folder=self.config.temp_folder,
                 workflow=self.config.workflow,

--- a/covigator/processor/abstract_processor.py
+++ b/covigator/processor/abstract_processor.py
@@ -1,4 +1,6 @@
 import abc
+import os
+import time
 import traceback
 from contextlib import suppress
 from datetime import datetime
@@ -28,17 +30,17 @@ class AbstractProcessor:
         assert self.database is not None, "Empty database"
         self.dask_client = dask_client
         assert self.dask_client is not None, "Empty dask client"
+        self.session = self.database.get_database_session()
+        self.queries = Queries(self.session)
 
     def process(self):
         logger.info("Starting processor")
-        session = self.database.get_database_session()
-        queries = Queries(session)
         count = 0
+        count_batch = 0
         try:
-            futures = []
             while True:
                 # queries 100 jobs every time to make sending to queue faster
-                jobs = queries.find_first_pending_jobs(self.data_source, n=1000)
+                jobs = self.queries.find_first_pending_jobs(self.data_source, n=1000)
                 if jobs is None or len(jobs) == 0:
                     logger.info("No more jobs to process after sending {} runs to process".format(count))
                     break
@@ -46,49 +48,46 @@ class AbstractProcessor:
                     # it has to update the status before doing anything so this processor does not read it again
                     job.status = JobStatus.QUEUED
                     job.queued_at = datetime.now()
-                    session.commit()
+                    self.session.commit()
 
                     # sends the run for processing
                     future = self._process_run(run_accession=job.run_accession)
-                    futures.append(future)
+                    fire_and_forget(future)
                     count += 1
+                    count_batch += 1
                     if count % 1000 == 0:
                         logger.info("Sent {} jobs for processing...".format(count))
 
                     # waits for a batch to finish
-                    if len(futures) >= self.config.batch_size:
+                    if count_batch >= self.config.batch_size:
                         # waits for a batch to finish before sending more
-                        self._wait_for_batch(futures)
-                        futures = []
+                        self._wait_for_batch()
+                        count_batch = 0
 
             # waits for the last batch to finish
-            if len(futures) > 0:
-                self._wait_for_batch(futures)
+            if count_batch > 0:
+                self._wait_for_batch()
             logger.info("Processor finished!")
         except Exception as e:
             logger.exception(e)
-            session.rollback()
+            self.session.rollback()
             self.error_message = self._get_traceback_from_exception(e)
             self.has_error = True
         finally:
             logger.info("Logging execution stats...")
-            self._write_execution_log(session, count, data_source=self.data_source)
+            self._write_execution_log(count, data_source=self.data_source)
             logger.info("Shutting down cluster and database session...")
             with suppress(Exception):
                 self.dask_client.shutdown()
-                session.close()
+                self.session.close()
             logger.info("Finished processor")
 
-    def _wait_for_batch(self, futures):
-        count_correct = 0
-        logger.info("Waiting for a batch of {} jobs...".format(len(futures)))
-        # self.dask_client.gather(futures=futures, errors='skip', direct=False)
-        for batch in as_completed(futures, with_results=True).batches():
-            for future, result in batch:
-                if result is not None:
-                    logger.info("Processed sample {}".format(result))
-                    count_correct += 1
-        logger.info("Batch processed with {} correct jobs".format(count_correct))
+    def _wait_for_batch(self):
+        logger.info("Waiting for a batch of jobs...")
+        while (count_pending_jobs := self.queries.count_jobs_in_queue(data_source=self.data_source)) > 0:
+            logger.info("Waiting for {} pending jobs".format(count_pending_jobs))
+            time.sleep(60)
+        logger.info("Batch finished")
 
     @staticmethod
     def run_job(config: Configuration, run_accession: str, start_status: JobStatus, end_status: JobStatus,
@@ -131,9 +130,9 @@ class AbstractProcessor:
     def _process_run(self, run_accession: str):
         pass
 
-    def _write_execution_log(self, session: Session, count, data_source: DataSource):
+    def _write_execution_log(self, count, data_source: DataSource):
         end_time = datetime.now()
-        session.add(Log(
+        self.session.add(Log(
             start=self.start_time,
             end=end_time,
             source=data_source,
@@ -144,7 +143,7 @@ class AbstractProcessor:
                 "processed": count
             }
         ))
-        session.commit()
+        self.session.commit()
 
     @staticmethod
     def _get_traceback_from_exception(e):

--- a/covigator/processor/gisaid_processor.py
+++ b/covigator/processor/gisaid_processor.py
@@ -45,7 +45,6 @@ class GisaidProcessor(AbstractProcessor):
         vcf = GisaidPipeline(config=config).run(sample=sample)
         job.analysed_at = datetime.now()
         job.vcf_path = vcf
-        return job.run_accession
 
     @staticmethod
     def load(job: JobGisaid, queries: Queries, config: Configuration):
@@ -53,4 +52,3 @@ class GisaidProcessor(AbstractProcessor):
             vcf_file=job.vcf_path, sample=Sample(id=job.run_accession, source=DataSource.GISAID),
             session=queries.session, max_snvs=MAX_SNVS, max_deletions=MAX_DELETIONS, max_insertions=MAX_INSERTIONS)
         job.loaded_at = datetime.now()
-        return job.run_accession

--- a/covigator/tests/unit_tests/test_downloader.py
+++ b/covigator/tests/unit_tests/test_downloader.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 from covigator.database.model import SampleEna
 from covigator.pipeline.downloader import Downloader, CovigatorMD5CheckSumError
@@ -25,7 +26,7 @@ class DownloaderTest(AbstractTest):
         with self.assertRaises(CovigatorMD5CheckSumError):
             self.downloader.download(ena_run)
 
-    def test_download_http(self):
+    def test_download_http_without_date(self):
         run_accession = "TEST12346"
         ena_run = SampleEna(
             run_accession=run_accession,
@@ -33,7 +34,20 @@ class DownloaderTest(AbstractTest):
             fastq_md5="ca72bacad0dfcf665df49bfc53cc8b60"
         )
         self.downloader.download(ena_run)
-        run_storage_folder = os.path.join(self.downloader.storage_folder, run_accession)
+        run_storage_folder = os.path.join(self.downloader.storage_folder, "nodate", run_accession)
+        self.assertTrue(os.path.exists(run_storage_folder))
+        self.assertTrue(os.path.exists(os.path.join(run_storage_folder, "TRON_Logo_Science.svg")))
+
+    def test_download_http_with_date(self):
+        run_accession = "TEST12346"
+        ena_run = SampleEna(
+            run_accession=run_accession,
+            fastq_ftp="https://tron-mainz.de/wp-content/uploads/2020/07/TRON_Logo_Science.svg",
+            fastq_md5="ca72bacad0dfcf665df49bfc53cc8b60",
+            collection_date=datetime.date(year=2021, month=6, day=30)
+        )
+        self.downloader.download(ena_run)
+        run_storage_folder = os.path.join(self.downloader.storage_folder, "20210630", run_accession)
         self.assertTrue(os.path.exists(run_storage_folder))
         self.assertTrue(os.path.exists(os.path.join(run_storage_folder, "TRON_Logo_Science.svg")))
 

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -18,7 +18,7 @@ class QueriesTests(AbstractTest):
         first_sample_date = None
         # adds 50 loaded and 50 failed samples, the date should only take into account loaded samples
         samples = mock_samples(faker=self.faker, session=self.session, num_samples=50, source=DataSource.ENA.name) + \
-                  mock_samples(faker=self.faker, session=self.session, job_status=JobStatus.FAILED_LOAD, num_samples=50,
+                  mock_samples(faker=self.faker, session=self.session, job_status=JobStatus.FAILED_PROCESSING, num_samples=50,
                                source=DataSource.ENA.name)
         for sample_ena, sample, job in samples:
             if job.status == JobStatus.FINISHED:
@@ -37,7 +37,7 @@ class QueriesTests(AbstractTest):
         most_recent_sample_date = None
         # adds 50 loaded and 50 failed samples, the date should only take into account loaded samples
         samples = mock_samples(faker=self.faker, session=self.session, num_samples=50, source=DataSource.ENA.name) + \
-                  mock_samples(faker=self.faker, session=self.session, job_status=JobStatus.FAILED_LOAD, num_samples=50,
+                  mock_samples(faker=self.faker, session=self.session, job_status=JobStatus.FAILED_PROCESSING, num_samples=50,
                                source=DataSource.ENA.name)
         for sample_ena, sample, job in samples:
             if job.status == JobStatus.FINISHED:


### PR DESCRIPTION
There were two different things that were causing trouble in the processor: 1) the active wait for the finalization of jobs and 2) the structure of sample data folders.

Regarding 1). We implemented an active based on Dask gather and wait operations, but with a high number of tasks, this was not working efficiently, so the last tasks in the queue were taking much much longer than tasks executed before the active wait started. The solution implemented here is to use Dask's `fire_and_forget()` and then implement the active based on the database jobs status. Also in relation to this, sending tasks to the cluster was very slow, as we were doing one query to the database per task. Now it queries in batches of 1000 tasks.

Regarding 2). The sample data folder were organized in a flat structure, which lead to a folder having a couple of million of subfolders. This reach system limits in our cluster. In order to solve this we have added the collection date to the folder hierarchy right before the sample name. This is related to this change https://github.com/TRON-Bioinformatics/covigator-ngs-pipeline/pull/4


Minor changes:
- The configuration is now not printed twice in the logs
- Remove old unused Job states from the data model