### PR TITLE
Fix ENA accessor pagination

### DIFF
--- a/covigator/__init__.py
+++ b/covigator/__init__.py
@@ -1,4 +1,4 @@
-VERSION = "0.4.0.dev5"
+VERSION = "0.4.0.dev6"
 
 MISSENSE_VARIANT = "missense_variant"
 SYNONYMOUS_VARIANT = "synonymous_variant"

--- a/covigator/accessor/ena_accessor.py
+++ b/covigator/accessor/ena_accessor.py
@@ -16,7 +16,7 @@ NUMBER_RETRIES = 5
 class EnaAccessor:
 
     ENA_API_URL_BASE = "https://www.ebi.ac.uk/ena/portal/api"
-    PAGE_SIZE = 100000
+    PAGE_SIZE = 1000000
     # see https://www.ebi.ac.uk/ena/portal/api/returnFields?result=read_run&format=json for all possible fields
     ENA_FIELDS = [
         # data on run

--- a/covigator/accessor/ena_accessor.py
+++ b/covigator/accessor/ena_accessor.py
@@ -19,7 +19,6 @@ NUMBER_RETRIES = 5
 class EnaAccessor:
 
     ENA_API_URL_BASE = "https://www.ebi.ac.uk/ena/portal/api"
-    PAGE_SIZE = 1000000
     # see https://www.ebi.ac.uk/ena/portal/api/returnFields?result=read_run&format=json for all possible fields
     ENA_FIELDS = [
         # data on run
@@ -93,23 +92,16 @@ class EnaAccessor:
 
     def access(self):
         logger.info("Starting ENA accessor")
-        offset = 0
-        finished = False
         session = self.database.get_database_session()
         # NOTE: holding in memory the whole list of existing ids is much faster than querying every time
         # it assumes there will be no repetitions
         existing_sample_ids = [value for value, in session.query(SampleEna.run_accession).all()]
         try:
-            while not finished:
-                list_runs = self._get_ena_runs_page(offset)
-                logger.info("Read page of {} ENA samples".format(len(list_runs)))
-                self._process_runs(list_runs, existing_sample_ids, session)
-                # finishes when no more data or when test parameter maximum is reached
-                if len(list_runs) < self.PAGE_SIZE or (self.maximum is not None and self.included >= self.maximum):
-                    finished = True
-                offset += len(list_runs)
-                if offset > 1000000:
-                    logger.warning("Reached an offset greater than 1,000,000 which ENA API does not support")
+            logger.info("Reading...")
+            list_runs = self._get_ena_runs_page()
+            logger.info("Processing {} ENA samples...".format(len(list_runs)))
+            self._process_runs(list_runs, existing_sample_ids, session)
+            logger.info("All samples processed!")
         except Exception as e:
             logger.exception(e)
             session.rollback()
@@ -121,15 +113,15 @@ class EnaAccessor:
             self._log_results()
             logger.info("Finished ENA accessor")
 
-    def _get_ena_runs_page(self, offset):
-        response : Response = self.get_with_retries("{url_base}/search?result=read_run&" \
-                                        "query=tax_eq({tax_id})&" \
-                                        "limit={page_size}&" \
-                                        "offset={offset}&" \
-                                        "fields={fields}&" \
-                                        "format=json".format(url_base=self.ENA_API_URL_BASE, tax_id=self.tax_id,
-                                                             page_size=self.PAGE_SIZE, offset=offset,
-                                                             fields=",".join(self.ENA_FIELDS)))
+    def _get_ena_runs_page(self):
+        # as communicated by ENA support we use limit=0 and offset=0 to get all records in one query
+        response: Response = self.get_with_retries(
+            "{url_base}/search?result=read_run&"
+            "query=tax_eq({tax_id})&"
+            "limit=0&"
+            "offset=0&"
+            "fields={fields}&"
+            "format=json".format(url_base=self.ENA_API_URL_BASE, tax_id=self.tax_id, fields=",".join(self.ENA_FIELDS)))
         try:
             json = response.json()
         except JSONDecodeError as e:

--- a/covigator/exceptions.py
+++ b/covigator/exceptions.py
@@ -1,48 +1,52 @@
 
 
-class CovigatorDatabaseConnectionException(Exception):
+class CovigatorException(Exception):
     pass
 
 
-class CovigatorPipelineError(Exception):
+class CovigatorDatabaseConnectionException(CovigatorException):
     pass
 
 
-class CovigatorDashBoardInitialisationError(Exception):
+class CovigatorPipelineError(CovigatorException):
     pass
 
 
-class CovigatorExcludedAssemblySequence(Exception):
+class CovigatorDashBoardInitialisationError(CovigatorException):
     pass
 
 
-class CovigatorNotSupportedVariant(Exception):
+class CovigatorExcludedAssemblySequence(CovigatorException):
     pass
 
 
-class CovigatorQueryException(Exception):
+class CovigatorNotSupportedVariant(CovigatorException):
     pass
 
 
-class CovigatorExcludedSampleTooEarlyDateException(Exception):
+class CovigatorQueryException(CovigatorException):
     pass
 
 
-class CovigatorExcludedSampleTooManyMutations(Exception):
+class CovigatorExcludedSampleTooEarlyDateException(CovigatorException):
     pass
 
 
-class CovigatorErrorProcessingCoverageResults(Exception):
+class CovigatorExcludedSampleTooManyMutations(CovigatorException):
     pass
 
 
-class CovigatorExcludedSampleNarrowCoverage(Exception):
+class CovigatorErrorProcessingCoverageResults(CovigatorException):
     pass
 
 
-class CovigatorExcludedSampleBadQualityReads(Exception):
+class CovigatorExcludedSampleNarrowCoverage(CovigatorException):
     pass
 
 
-class CovigatorDashboardMissingPrecomputedData(Exception):
+class CovigatorExcludedSampleBadQualityReads(CovigatorException):
+    pass
+
+
+class CovigatorDashboardMissingPrecomputedData(CovigatorException):
     pass

--- a/covigator/tests/unit_tests/faked_objects.py
+++ b/covigator/tests/unit_tests/faked_objects.py
@@ -33,5 +33,5 @@ class FakeEnaAccessor(EnaAccessor):
                          database=database if database else Database(test=True, config=Configuration()))
         self.results = results
 
-    def _get_ena_runs_page(self, offset):
+    def _get_ena_runs_page(self):
         return self.results


### PR DESCRIPTION
The ENA API was found to have a limitation in their pagination implementation. The offset could never be greater than 1000000. After asking ENA support they suggested to make a single request with no limit in the page size, so the offset does not need to be used at all. They communicated that a change of database is planned in order to support pagination over a larger dataset.