### PR TITLE
102 lineage metadata in dashboard

### DIFF
--- a/covigator/dashboard/figures/lineages.py
+++ b/covigator/dashboard/figures/lineages.py
@@ -62,10 +62,9 @@ class LineageFigures(Figures):
             data_source=data_source, countries=countries, lineages=lineages)
         graph = dcc.Markdown("""**No data for the current selection**""")
         if data is not None and data.shape[0] > 0:
-            # Generate a dictionary mapping pangolin lineage ids to the WHO labels in the database
-            # Create a new combo label of pangolin ids + WHO labels between brackets e.g. B.1.1.7 - Alpha
-            # to be used in the legend of the lineages plot
-            label_names = data.merge(who_label, how="left", left_on="lineage", right_on="pangolin_lineage")[['lineage', 'who_label']]
+            # Generate a dictionary mapping pangolin lineage ids in the dataframe to the WHO labels in the database
+            # Use combo label of pangolin ids + WHO labels separated by a hyphen in the legend of the lineages plot
+            label_names = data.merge(who_label, how="left", left_on="lineage", right_on="pangolin_lineage")[["lineage","who_label"]]
             label_names["label_value"] = label_names.apply(lambda x: f"{x.lineage} - {x.who_label}"
                 if not pd.isnull(x.who_label) else f"{x.lineage}", axis=1)
             label_names = label_names.set_index("lineage").to_dict()["label_value"]

--- a/covigator/dashboard/tabs/dataset_ena.py
+++ b/covigator/dashboard/tabs/dataset_ena.py
@@ -54,7 +54,7 @@ def get_ena_overview_tab_left_bar(queries: Queries):
         children=[
             html.Div([
                 html.Div(dbc.Button(
-                    "Distribution of samples by library strategy",
+                    "Samples by library strategy",
                     color="secondary",
                     className="me-1",
                     style={'font-size': '100%'}

--- a/covigator/dashboard/tabs/intrahost_mutations.py
+++ b/covigator/dashboard/tabs/intrahost_mutations.py
@@ -79,7 +79,7 @@ def get_subclonal_variants_tab_left_bar(queries: Queries):
             )),
             html.Br(),
             html.Div(dbc.Button(
-                "Distribution of selected intrahost mutation",
+                "Selected intrahost mutation",
                 color="secondary",
                 className="me-1",
                 style={'font-size': '100%'})),

--- a/covigator/dashboard/tabs/lineages.py
+++ b/covigator/dashboard/tabs/lineages.py
@@ -1,4 +1,5 @@
 from datetime import timedelta, datetime
+import pandas as pd
 from dash import dcc
 import dash_bootstrap_components as dbc
 from dash import html
@@ -49,13 +50,17 @@ def get_lineages_tab_graphs():
 
 def get_lineages_tab_left_bar(queries: Queries, data_source: DataSource):
 
-    lineages = queries.get_lineages(source=data_source.name)
+    lineages = pd.DataFrame(queries.get_lineages(source=data_source.name), columns=["pangolin_lineage"])
+    lineages = lineages.merge(queries.get_lineages_who_label(), how="left")
+    lineages["dropdown_label"] = lineages.apply(lambda x: f"{x.pangolin_lineage} - {x.who_label}"
+        if not pd.isnull(x.who_label) else f"{x.pangolin_lineage}", axis=1)
     # Get all available months from collection_date column in sample table
     months = queries.get_sample_months(MONTH_PATTERN, data_source=data_source.name)
     today = datetime.now()
     today_formatted = today.strftime(MONTH_PATTERN)
     oneyearago = today - timedelta(days=356)
     oneyearago_formatted = oneyearago.strftime(MONTH_PATTERN)
+
 
     return html.Div(
         className="two columns",
@@ -106,7 +111,7 @@ def get_lineages_tab_left_bar(queries: Queries, data_source: DataSource):
             dcc.Markdown("""Select one or more lineages"""),
             dcc.Dropdown(
                 id=ID_DROPDOWN_LINEAGE,
-                options=[{'label': c, 'value': c} for c in queries.get_lineages(data_source.name)],
+                options=[{'label': c, 'value': v} for c, v in zip(lineages.dropdown_label, lineages.pangolin_lineage)],
                 value=None,
                 multi=True
             ),
@@ -158,11 +163,22 @@ def set_callbacks_lineages_tab(app, session: Session):
 
     queries = Queries(session=session)
     figures = LineageFigures(queries)
+    # Get dataframe mapping pangolin lineage ids to WHO labels
+    who_labels = queries.get_lineages_who_label()
 
     countries_ena = queries.get_countries(DataSource.ENA.name)
     countries_covid19_portal = queries.get_countries(DataSource.COVID19_PORTAL.name)
-    lineages_ena = queries.get_lineages(DataSource.ENA.name)
-    lineages_covid19_portal = queries.get_lineages(DataSource.COVID19_PORTAL.name)
+
+    # Append WHO label to dataframe of ENA/Covid19_Portal lineages and create label for dropdown menus.
+    lineages_ena = pd.DataFrame(queries.get_lineages(DataSource.ENA.name), columns=["pangolin_lineage"])
+    lineages_ena = lineages_ena.merge(who_labels, how="left")
+    lineages_ena["dropdown_label"] = lineages_ena.apply(lambda x: f"{x.pangolin_lineage} - {x.who_label}"
+        if not pd.isnull(x.who_label) else f"{x.pangolin_lineage}", axis=1)
+
+    lineages_covid19_portal = pd.DataFrame(queries.get_lineages(DataSource.COVID19_PORTAL.name), columns=["pangolin_lineage"])
+    lineages_covid19_portal = lineages_covid19_portal.merge(who_labels, how="left")
+    lineages_covid19_portal["dropdown_label"] = lineages_covid19_portal.apply(lambda x: f"{x.pangolin_lineage} - {x.who_label}"
+        if not pd.isnull(x.who_label) else f"{x.pangolin_lineage}", axis=1)
 
     # Get months from ENA/Covid19 table
     months_from_db_ena = queries.get_sample_months(MONTH_PATTERN, data_source=DataSource.ENA.name)
@@ -191,9 +207,9 @@ def set_callbacks_lineages_tab(app, session: Session):
         """
         lineages = []
         if source == DataSource.ENA.name:
-            lineages = [{'label': c, 'value': c} for c in lineages_ena]
+            lineages = [{'label': c, 'value': v} for c, v in zip(lineages_ena.dropdown_label, lineages_ena.pangolin_lineage)]
         elif source == DataSource.COVID19_PORTAL.name:
-            lineages = [{'label': c, 'value': c} for c in lineages_covid19_portal]
+            lineages = [{'label': c, 'value': v} for c, v in zip(lineages_covid19_portal.dropdown_label, lineages_covid19_portal.pangolin_lineage)]
         return lineages
 
     @app.callback(
@@ -202,6 +218,9 @@ def set_callbacks_lineages_tab(app, session: Session):
         Input(ID_DROPDOWN_DATA_SOURCE, 'value')
     )
     def update_dropdown_end_date(start_date, data_source):
+        """
+        Updates the date selection slider when data source is changed
+        """
         today = datetime.now()
         today_formatted = today.strftime(MONTH_PATTERN)
         months = []

--- a/covigator/dashboard/tabs/samples.py
+++ b/covigator/dashboard/tabs/samples.py
@@ -43,6 +43,8 @@ def get_samples_tab_graphs():
 
 
 def get_samples_tab_left_bar(queries: Queries, data_source: DataSource):
+
+    lineages = queries.get_combined_labels(data_source.name)
     return html.Div(
         className="two columns",
         children=[
@@ -81,7 +83,7 @@ def get_samples_tab_left_bar(queries: Queries, data_source: DataSource):
             dcc.Markdown("""Select one or more lineages"""),
             dcc.Dropdown(
                 id=ID_DROPDOWN_LINEAGE,
-                options=[{'label': c, 'value': c} for c in queries.get_lineages(data_source.name)],
+                options=[{'label': c, 'value': v} for c, v in zip(lineages.combined_label, lineages.pangolin_lineage)],
                 value=None,
                 multi=True
             ),
@@ -117,8 +119,8 @@ def set_callbacks_samples_tab(app, session: Session):
 
     countries_ena = queries.get_countries(DataSource.ENA.name)
     countries_covid19_portal = queries.get_countries(DataSource.COVID19_PORTAL.name)
-    lineages_ena = queries.get_lineages(DataSource.ENA.name)
-    lineages_covid19_portal = queries.get_lineages(DataSource.COVID19_PORTAL.name)
+    lineages_ena = queries.get_combined_labels(source=DataSource.ENA.name)
+    lineages_covid19_portal = queries.get_combined_labels(source=DataSource.COVID19_PORTAL.name)
 
     @app.callback(
         Output(ID_DROPDOWN_COUNTRY, 'options'),
@@ -129,9 +131,9 @@ def set_callbacks_samples_tab(app, session: Session):
         """
         countries = []
         if source == DataSource.ENA.name:
-            countries = [{'label': c, 'value': c} for c in countries_ena]
+            countries = [{'label': c, 'value': c} for c in lineages_ena]
         elif source == DataSource.COVID19_PORTAL.name:
-            countries = [{'label': c, 'value': c} for c in countries_covid19_portal]
+            countries = [{'label': c, 'value': c} for c in lineages_covid19_portal]
         return countries
 
     @app.callback(
@@ -143,9 +145,9 @@ def set_callbacks_samples_tab(app, session: Session):
         """
         lineages = []
         if source == DataSource.ENA.name:
-            lineages = [{'label': c, 'value': c} for c in lineages_ena]
+            lineages = [{'label': c, 'value': v} for c, v in zip(lineages_ena.combined_label, lineages_ena.pangolin_lineage)]
         elif source == DataSource.COVID19_PORTAL.name:
-            lineages = [{'label': c, 'value': c} for c in lineages_covid19_portal]
+            lineages = [{'label': c, 'value': v} for c, v in zip(lineages_covid19_portal.combined_label, lineages_covid19_portal.pangolin_lineage)]
         return lineages
 
     @app.callback(

--- a/covigator/dashboard/tabs/samples.py
+++ b/covigator/dashboard/tabs/samples.py
@@ -131,9 +131,9 @@ def set_callbacks_samples_tab(app, session: Session):
         """
         countries = []
         if source == DataSource.ENA.name:
-            countries = [{'label': c, 'value': c} for c in lineages_ena]
+            countries = [{'label': c, 'value': c} for c in countries_ena]
         elif source == DataSource.COVID19_PORTAL.name:
-            countries = [{'label': c, 'value': c} for c in lineages_covid19_portal]
+            countries = [{'label': c, 'value': c} for c in countries_covid19_portal]
         return countries
 
     @app.callback(

--- a/covigator/database/queries.py
+++ b/covigator/database/queries.py
@@ -128,19 +128,15 @@ class Queries:
         """
         Query database for lineage WHO label annotation. Returns a DataFrame with columns: pangolin_lineage, who_label
         """
-        query = self.session.query(Lineages.pango_lineage_id.label("pangolin_lineage"), Lineages.who_label,
-                                   Lineages.parent_lineage_id)
+        query = self.session.query(Lineages.pango_lineage_id.label("pangolin_lineage"), Lineages.who_label)
         lineages = pd.read_sql(query.statement, self.session.bind)
-        # Include WHO label for sublineages of VOC
-        lineages["who_label"] = lineages.apply(lambda x: self.find_parent_who_label(x.pangolin_lineage, lineages)
-            if pd.isnull(x.who_label) else x.who_label, axis=1)
         lineages = lineages[["pangolin_lineage", "who_label"]]
         return lineages
 
     def get_combined_labels(self, source: str) -> pd.DataFrame:
         """
-        Generate a mapping of pangolin IDs to WHO label and create a combined label that is used in the
-        dashboard
+        Create a mapping from pangolin IDs in the data source to WHO identifiers and create a combined
+        label to be used in the dashboard
         """
         who_labels = self.get_lineages_who_label()
         lineages = self.get_lineages(source)

--- a/covigator/database/queries.py
+++ b/covigator/database/queries.py
@@ -145,7 +145,7 @@ class Queries:
         who_labels = self.get_lineages_who_label()
         lineages = pd.DataFrame(self.get_lineages(source), columns=["pangolin_lineage"])
         lineages = lineages.merge(who_labels, how="left")
-        lineages["combined_label"] = lineages.apply(lambda x: f"{x.pangolin_lineage} - {x.who_label}" \
+        lineages["combined_label"] = lineages.apply(lambda x: f"{x.pangolin_lineage} - {x.who_label}"
             if not pd.isnull(x.who_label) else f"{x.pangolin_lineage}", axis=1)
         return lineages
 

--- a/covigator/database/queries.py
+++ b/covigator/database/queries.py
@@ -143,7 +143,10 @@ class Queries:
         dashboard
         """
         who_labels = self.get_lineages_who_label()
-        lineages = pd.DataFrame(self.get_lineages(source), columns=["pangolin_lineage"])
+        lineages = self.get_lineages(source)
+        if not lineages:
+            return None
+        lineages = pd.DataFrame(lineages, columns=["pangolin_lineage"])
         lineages = lineages.merge(who_labels, how="left")
         lineages["combined_label"] = lineages.apply(lambda x: f"{x.pangolin_lineage} - {x.who_label}"
             if not pd.isnull(x.who_label) else f"{x.pangolin_lineage}", axis=1)

--- a/covigator/tests/unit_tests/test_database_initialisation.py
+++ b/covigator/tests/unit_tests/test_database_initialisation.py
@@ -96,7 +96,7 @@ class DatabaseInitialisationTests(AbstractTest):
         # Check that parents are all present in lineage table
         self.assertTrue(all([x in pango_ids for x in lineages_with_parents.parent_lineage_id]))
         omicron = lineages_with_parents.loc[lineages_with_parents["who_label"] == "Omicron"]
-        self.assertTrue(all([x in ["B.1.1.529", "XE-parent2"] for x in omicron.parent_lineage_id]))
+        self.assertTrue(all([x in ["B.1.1.529", "XE-parent2", "XE-parent1"] for x in omicron.parent_lineage_id]))
 
         # check that VOC information is parsed correctly
         voc_query = session.query(Lineages).filter(Lineages.variant_of_concern.is_(True))

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -12,7 +12,6 @@ from covigator.tests.unit_tests.mocked import get_mocked_variant, \
     get_mocked_variant_observation, mock_samples, mock_cooccurrence_matrix, mock_samples_and_variants, MOCKED_DOMAINS, \
     get_mocked_sample
 
-
 class QueriesTests(AbstractTest):
 
     def setUp(self) -> None:
@@ -206,6 +205,7 @@ class QueriesTests(AbstractTest):
         self.assertGreater(who_labels[~who_labels.who_label.isna()].shape[0], 0) # no emtpy who labels
 
     def test_find_parent_who_label(self):
+        import pandas as pd
         query = self.session.query(Lineages.pango_lineage_id.label("pangolin_lineage"), Lineages.who_label,
                                    Lineages.parent_lineage_id)
         data = pd.read_sql(query.statement, self.session.bind)

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -5,7 +5,7 @@ from parameterized import parameterized
 from covigator import SYNONYMOUS_VARIANT
 from covigator.precomputations.loader import PrecomputationsLoader
 from covigator.precomputations.load_ns_s_counts import NsSCountsLoader
-from covigator.database.model import JobStatus, DataSource, Gene, RegionType, Domain
+from covigator.database.model import JobStatus, DataSource, Gene, RegionType, Domain, Lineages
 from covigator.database.queries import Queries
 from covigator.tests.unit_tests.abstract_test import AbstractTest
 from covigator.tests.unit_tests.mocked import get_mocked_variant, \
@@ -198,6 +198,19 @@ class QueriesTests(AbstractTest):
             self.assertIsInstance(d, Domain)
             self.assertIsNotNone(d.name)
             self.assertEqual(d.gene_name, "S")
+
+    def test_get_lineages_who_label(self):
+        who_labels = self.queries.get_lineages_who_label()
+        self.assertIsNotNone(who_labels)
+        self.assertGreater(who_labels.shape[0], 0)
+        self.assertGreater(who_labels[~who_labels.who_label.isna()].shape[0], 0) # no emtpy who labels
+
+    def test_find_parent_who_label(self):
+        query = self.session.query(Lineages.pango_lineage_id.label("pangolin_lineage"), Lineages.who_label,
+                                   Lineages.parent_lineage_id)
+        data = pd.read_sql(query.statement, self.session.bind)
+        who_label = self.queries.find_parent_who_label("AY.4.2", data)
+        self.assertEqual(who_label, "Delta")
 
     def test_count_jobs_in_queue(self):
         mock_samples(faker=self.faker, session=self.session, job_status=JobStatus.QUEUED, num_samples=50)

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -213,8 +213,11 @@ class QueriesTests(AbstractTest):
         self.assertEqual(who_label, "Delta")
         who_label = self.queries.find_parent_who_label("AY.4", data)
         self.assertEqual(who_label, "Delta")
+        who_label = self.queries.find_parent_who_label("XE-parent2", data)
+        self.assertEqual(who_label, "Omicron")
 
-    @parameterized.expand([(DataSource.ENA,)])
+
+    @parameterized.expand([(DataSource.ENA, DataSource.COVID19_PORTAL)])
     def test_get_combined_labels(self, source):
         # Mock some ENA samples
         labels = self.queries.get_combined_labels(source.name)

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -217,7 +217,7 @@ class QueriesTests(AbstractTest):
         self.assertEqual(who_label, "Omicron")
 
 
-    @parameterized.expand([(DataSource.ENA, DataSource.COVID19_PORTAL)])
+    @parameterized.expand([(DataSource.ENA,), (DataSource.COVID19_PORTAL,)])
     def test_get_combined_labels(self, source):
         # Mock some ENA samples
         labels = self.queries.get_combined_labels(source.name)

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -217,7 +217,7 @@ class QueriesTests(AbstractTest):
         self.assertEqual(who_label, "Omicron")
 
 
-    @parameterized.expand([(DataSource.ENA,), (DataSource.COVID19_PORTAL,)])
+    @parameterized.expand([(DataSource.ENA, )])
     def test_get_combined_labels(self, source):
         # Mock some ENA samples
         labels = self.queries.get_combined_labels(source.name)

--- a/scripts/sql/20230412_patch_lineage_delta.sql
+++ b/scripts/sql/20230412_patch_lineage_delta.sql
@@ -1,0 +1,2 @@
+UPDATE lineage_test SET who_label='Delta' WHERE pango_lineage_id = 'AY.1';
+UPDATE lineage_test SET who_label='Delta' WHERE pango_lineage_id = 'AY.2';


### PR DESCRIPTION
Use lineage metadata from #61 to enrich the dashboard. Update the combo boxes in the lineages and samples tab to show a combination of pangolin id and WHO label.