### PR TITLE
62 annotate lineages with described mutations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include covigator/references/*.bed
 include covigator/references/*.csv
 include covigator/references/*.json
 include covigator/references/constellations/constellations/definitions/*.json
+include covigator/references/constellations/constellations/data/SARS-CoV-2.json 
 include covigator/tests/resources/*

--- a/covigator/__init__.py
+++ b/covigator/__init__.py
@@ -9,3 +9,18 @@ DISRUPTIVE_INFRAME_DELETION = "disruptive_inframe_deletion"
 CONSERVATIVE_INFRAME_DELETION = "conservative_inframe_deletion"
 DISRUPTIVE_INFRAME_INSERTION = "disruptive_inframe_insertion"
 CONSERVATIVE_INFRAME_INSERTION = "conservative_inframe_insertion"
+INTERGENIC_VARIANT = "intergenic_variant"
+INTERGENIC_DELETION = "intergenic_deletion"
+FRAMESHIFT_VARIANT = "frameshift_variant"
+
+CANONICAL_PROTEIN_MAPPING = {
+            "S": ["S", "s", "spike"],
+            "N": ["N", "n"],
+            "M": ["M", "m"],
+            "E": ["E", "e"],
+            "ORF1ab": ["ORF1ab", "1ab", "orf1ab", "ORF1a", "ORF1b", "orf1a", "orf1b", "nsp3", "nsp6", "nsp5", "nsp4",
+                       "nsp15", "nsp13", "nsp7", "nsp12", "NSP2"],
+            "ORF3a": ["ORF3a", "orf3a"],
+            "ORF8": ["ORF8", "8"],
+            "ORF6": ["ORF6", "orf6"]
+        }

--- a/covigator/__init__.py
+++ b/covigator/__init__.py
@@ -18,9 +18,15 @@ CANONICAL_PROTEIN_MAPPING = {
             "N": ["N", "n"],
             "M": ["M", "m"],
             "E": ["E", "e"],
-            "ORF1ab": ["ORF1ab", "1ab", "orf1ab", "ORF1a", "ORF1b", "orf1a", "orf1b", "nsp3", "nsp6", "nsp5", "nsp4",
-                       "nsp15", "nsp13", "nsp7", "nsp12", "NSP2"],
+            "ORF1ab": ["ORF1ab", "1ab", "orf1ab", "ORF1a", "ORF1b", "orf1a", "orf1b", "nsp1", "NSP1", "nsp2", "NSP2",
+                       "nsp3", "NSP3", "nsp4", "NSP4", "nsp5", "NSP5", "nsp6", "NSP6", "nsp7", "NSP7", "nsp8", "NSP8",
+                       "nsp9", "NSP9", "nsp10", "NSP10", "nsp11", "NSP11", "nsp12", "NSP12", "nsp13", "NSP13", "nsp14",
+                       "NSP14", "nsp15", "NSP15", "nsp16", "NSP16"],
             "ORF3a": ["ORF3a", "orf3a"],
-            "ORF8": ["ORF8", "8"],
-            "ORF6": ["ORF6", "orf6"]
+            "ORF8": ["ORF8", "orf8", "8"],
+            "ORF6": ["ORF6", "orf6"],
+            "ORF7a": ["ORF7a", "orf7a"],
+            "ORF7b": ["ORF7b", "orf7b"],
+            "ORF10": ["ORF10", "orf10", "10"],
+
         }

--- a/covigator/database/model.py
+++ b/covigator/database/model.py
@@ -1173,7 +1173,7 @@ class LineageDefiningVariants(Base):
     reference = Column(String)
     alternate = Column(String)
     ambiguous_alternate = Column(Boolean, default=False)
-    annotation = Column(String, default="non-synonymous")
+    annotation = Column(String, default="missense")
     hgvs = Column(String)
 
     constellations = relationship(

--- a/covigator/database/model.py
+++ b/covigator/database/model.py
@@ -1081,7 +1081,7 @@ class RegionType(enum.Enum):
 
     GENE = 1
     DOMAIN = 2
-    CODING_REGION=3
+    CODING_REGION = 3
 
 
 class PrecomputedSynonymousNonSynonymousCounts(Base):
@@ -1165,7 +1165,7 @@ class VariantLevel(enum.Enum):
     __constraint_name__ = VARIANT_LEVEL_CONSTRAINT_NAME
 
     PROTEOMIC = 1
-    NUCLEOTIDE = 2
+    GENOMIC = 2
 
 
 class LineageDefiningVariants(Base):

--- a/covigator/database/model.py
+++ b/covigator/database/model.py
@@ -51,6 +51,7 @@ VARIANT_TYPE_CONSTRAINT_NAME = get_table_versioned_name('variant_type', config=c
 LINEAGE_TABLE_NAME = get_table_versioned_name('lineage', config=config)
 CONSTELLATION_SITES_TABLE_NAME = get_table_versioned_name('lineage_defining_variant', config=config)
 LINEAGE_SITES_JUNCTION_TABLE_NAME = get_table_versioned_name('lineage_variant', config=config)
+VARIANT_LEVEL_CONSTRAINT_NAME = get_table_versioned_name('variant_level', config=config)
 SEPARATOR = ";"
 
 Base = declarative_base()
@@ -1160,6 +1161,13 @@ class Lineages(Base):
     )
 
 
+class VariantLevel(enum.Enum):
+    __constraint_name__ = VARIANT_LEVEL_CONSTRAINT_NAME
+
+    PROTEOMIC = 1
+    NUCLEOTIDE = 2
+
+
 class LineageDefiningVariants(Base):
     """
     Store lineage defining mutations as defined in the scorpio constellation files. Mutations can be in nucleotide
@@ -1183,7 +1191,7 @@ class LineageDefiningVariants(Base):
     ambiguous_alternate = Column(Boolean, default=False)
     annotation = Column(String)
     hgvs = Column(String)
-    variant_level = Column(String)
+    variant_level = Column(Enum(VariantLevel, name=VariantLevel.__constraint_name__))
 
     constellations = relationship(
         "Lineages",

--- a/covigator/database/model.py
+++ b/covigator/database/model.py
@@ -1175,12 +1175,12 @@ class LineageDefiningVariants(Base):
     ambiguous_alternate = Column(Boolean, default=False)
     annotation = Column(String, default="missense")
     hgvs = Column(String)
+    variant_level = Column(String)
 
     constellations = relationship(
         "Lineages",
         secondary=LINEAGE_SITES_JUNCTION_TABLE_NAME,
         back_populates="variants")
-
 
 
 class LineageVariant(Base):

--- a/covigator/database/model.py
+++ b/covigator/database/model.py
@@ -1162,12 +1162,12 @@ class Lineages(Base):
 
 class LineageDefiningVariants(Base):
     """
-    Store lineage defining mutations as defined in the scorpio constellation files. Mutations can be on nucleotide
+    Store lineage defining mutations as defined in the scorpio constellation files. Mutations can be in nucleotide
     (intergenic) or proteomic space. The columns variant_id, position, reference and alternate therefore have different
     meanings and formatting
 
     Variant_id: position_in_genome:[reference_bases]>[alternate_nuc] (genomic level)
-                canonical_protein_name:[reference_aa]position_in_protein[alternate_aa]
+                canonical_protein_name:[reference_aa]position_in_protein[alternate_aa] (proteomic level)
     position: position_in_genome (genomic level) or position_in_protein (proteomic level)
     reference: reference_bases (genomic level) or reference_aa (proteomic level)
     alternate: alternate_bases (genomic level) or alternate_aa (proteomic level)

--- a/covigator/database/model.py
+++ b/covigator/database/model.py
@@ -1162,18 +1162,26 @@ class Lineages(Base):
 
 class LineageDefiningVariants(Base):
     """
-    Store lineage defining mutations
+    Store lineage defining mutations as defined in the scorpio constellation files. Mutations can be on nucleotide
+    (intergenic) or proteomic space. The columns variant_id, position, reference and alternate therefore have different
+    meanings and formatting
+
+    Variant_id: position_in_genome:[reference_bases]>[alternate_nuc] (genomic level)
+                canonical_protein_name:[reference_aa]position_in_protein[alternate_aa]
+    position: position_in_genome (genomic level) or position_in_protein (proteomic level)
+    reference: reference_bases (genomic level) or reference_aa (proteomic level)
+    alternate: alternate_bases (genomic level) or alternate_aa (proteomic level)
     """
     __tablename__ = CONSTELLATION_SITES_TABLE_NAME
 
     variant_id = Column(String, primary_key=True)
-    variant_type = Column(String)
+    variant_type = Column(Enum(VariantType, name=VariantType.__constraint_name__))
     protein = Column(String)
     position = Column(Integer, index=True)
     reference = Column(String)
     alternate = Column(String)
     ambiguous_alternate = Column(Boolean, default=False)
-    annotation = Column(String, default="missense")
+    annotation = Column(String)
     hgvs = Column(String)
     variant_level = Column(String)
 

--- a/covigator/database/model.py
+++ b/covigator/database/model.py
@@ -1189,8 +1189,7 @@ class LineageVariant(Base):
     Junction table that maps constellation sites to their respective lineage
     """
     __tablename__ = LINEAGE_SITES_JUNCTION_TABLE_NAME
-    #constellation_id = Column(String, primary_key=True)
-    #pango_lineage_id = Column(String, primary_key=True)
+
     pango_lineage_id = Column(ForeignKey(Lineages.pango_lineage_id), primary_key=True)
     variant_id = Column(ForeignKey(LineageDefiningVariants.variant_id), primary_key=True)
 

--- a/covigator/database/model.py
+++ b/covigator/database/model.py
@@ -1174,14 +1174,13 @@ class LineageDefiningVariants(Base):
     alternate = Column(String)
     ambiguous_alternate = Column(Boolean, default=False)
     annotation = Column(String, default="non-synonymous")
+    hgvs = Column(String)
 
     constellations = relationship(
         "Lineages",
         secondary=LINEAGE_SITES_JUNCTION_TABLE_NAME,
         back_populates="variants")
 
-    def get_variant_id(self):
-        return "{}:{}{}{}".format(self.protein, self.reference, self.position, self.alternate)
 
 
 class LineageVariant(Base):
@@ -1193,9 +1192,3 @@ class LineageVariant(Base):
     pango_lineage_id = Column(ForeignKey(Lineages.pango_lineage_id), primary_key=True)
     variant_id = Column(ForeignKey(LineageDefiningVariants.variant_id), primary_key=True)
 
-    #__table_args__ = (
-    #    ForeignKeyConstraint(
-    #        ['constellation_id', 'pango_lineage_id'],
-    #        [Lineages.constellation_id, Lineages.pango_lineage_id],
-    #    ),
-    #)

--- a/covigator/references/lineage_annotation.py
+++ b/covigator/references/lineage_annotation.py
@@ -338,7 +338,7 @@ class LineageAnnotationsLoader:
                 protein=gene)
 
         position_in_cds = position - (gene_start - 1)
-        protein_position = self._get_protein_position(position_in_cds)
+        protein_position = self.get_protein_position(position_in_cds)
         # Get wild type and mutated codon sequence
         if position_in_cds % 3 == 0:
             wt_codon = self.genome[(position - 2) - 1: position]

--- a/covigator/references/lineage_annotation.py
+++ b/covigator/references/lineage_annotation.py
@@ -1,9 +1,10 @@
 import os
 import json
+import re
 from pathlib import Path
 
 from sqlalchemy.orm import Session
-from covigator.database.model import Lineages
+from covigator.database.model import Lineages, LineageDefiningVariants, LineageVariant
 from logzero import logger
 from datetime import datetime
 
@@ -17,6 +18,132 @@ class LineageAnnotationsLoader:
 
         self.lineage_constellation_directory = os.path.join(
             os.path.abspath(os.path.dirname(__file__)), self.LINEAGE_CONSTELLATION_DIRECTORY)
+
+    @staticmethod
+    def _match_protein_name(protein_name: str):
+        """
+        This method provides a mapping between canonical protein/gene names and common synonyms.
+        """
+        protein_mapping = {
+            "S": ["S", "s", "spike"],
+            "N": ["N", "n"],
+            "M": ["M", "m"],
+            "E": ["E", "e"],
+            "ORF1ab": ["ORF1ab", "1ab", "orf1ab", "ORF1a", "ORF1b", "orf1a", "orf1b", "nsp3", "nsp6", "nsp5", "nsp4",
+                       "nsp15", "nsp13", "nsp7", "nsp12", "NSP2"],
+            "ORF3a": ["ORF3a", "orf3a"],
+            "ORF8": ["ORF8", "8"],
+            "ORF6": ["ORF6", "orf6"]
+        }
+        if protein_name is None:
+            return None
+        for canonical_name, synonyms in protein_mapping.items():
+            if protein_name in synonyms:
+                return canonical_name
+        return protein_name
+
+    def _parse_mutation_sites(self, variant_string: str):
+        """
+        Parse mutation list from pango constellation files. This code
+        is based on the parser found in the utility script of scorpio
+        for now limited to SNPs, Indels and Insertion in protein coordinates.
+
+        s:Y144- --> Deletion on AA level
+        del:21765:6 --> Deletion on nucleotide level
+
+        nuc:C16176T  --> SNV on nucleotide level
+        s:A570D --> SNV on AA level
+        n:RG203KR --> MNV on AA level
+
+        nuc:22205+GAGCCAGAA --> Insertion on nucleotide level
+
+        """
+        snp_pattern = re.compile('([ACTGUN]+)([0-9]+)([ACTGUN]+)')
+        insertion_pattern = re.compile(r'(\w+):(\d+)\+([a-zA-Z]+)')
+        aa_mutation = re.compile(r'([a-zA-Z-*]+)(\d+)([a-zA-Z-*]*)')
+        mutation_info = {}
+        # This parsing is simplified code based on the utility script of Scorpio
+        this_mut = variant_string.split(":")
+        # Insertions -> eiter nucleotide or protein coordinates
+        if "+" in variant_string:
+            match = re.match(insertion_pattern, variant_string)
+            if not match:
+                logger.warning("Could not parse the following site definition: {}".format(variant_string))
+                return
+            # Does not work with aa level insertions but None are present in the current constellation files
+            mutation_info = {"site": variant_string,
+                             "type": "Insertion",
+                             "position": match[2],
+                             "length": len(match[2]),
+                             "protein": self._match_protein_name(match[1]),
+                             "alternate": match[3],
+                             "level": "nuc"}
+            if not this_mut[0] in ["snp", "nuc"]:
+                mutation_info["level"] = "aa"
+
+        # Deletions -> coordinates on nucleotide level
+        elif this_mut[0] == "del":
+            length = int(this_mut[2])
+            mutation_info = {"site": variant_string,
+                             "type": "Deletion",
+                             "position": this_mut[1],
+                             "length": length,
+                             "protein": None,
+                             "level": "nuc"}
+        # SNPs -> coordinates on nucleotide level, non-synonymous or intergenic?
+        elif this_mut[0] in ["snp", "nuc"]:
+            match = re.match(snp_pattern, this_mut[1])
+            if not match:
+                logger.warning("Could not parse the following site definition: {}".format(variant_string))
+                return
+            mutation_info = {"site": variant_string,
+                             "type": "SNV",
+                             "position": int(match[2]),
+                             "reference": match[1],
+                             "alternate": match[3],
+                             "protein": None,
+                             "level": "nuc"}
+            mutation_info['variant_id'] = "{}:{}{}{}".format(mutation_info["protein"], mutation_info["reference"],
+                                                             mutation_info["position"], mutation_info["alternate"])
+        # Amino acid substitutions --> can be SNVs, MNVs, Deletions and Indels
+        else:
+            match = re.match(aa_mutation, this_mut[1])
+            if not match:
+                logger.warning("Could not parse the following site definition: {}".format(variant_string))
+                return
+            protein = self._match_protein_name(this_mut[0])
+            mutation_info = {"site": variant_string,
+                             "type": "SNV",
+                             "position": int(match[2]),
+                             "reference": match[1],
+                             "alternate": match[3],
+                             "protein": protein,
+                             "ambiguous_alternate": False,
+                             "length": len(match[1]),
+                             "level": "aa"}
+            mutation_info['variant_id'] = "{}:{}{}{}".format(mutation_info["protein"], mutation_info["reference"],
+                                                             mutation_info["position"], mutation_info["alternate"])
+            # Ambigous alternatives are possible
+            if mutation_info["alternate"] == '':
+                mutation_info["ambiguous_alternate"] = True
+            # If AA mutation is a deletion
+            if mutation_info["alternate"] in ["-", "del"]:
+                mutation_info["type"] = "Deletion"
+            elif len(mutation_info["alternate"]) == len(mutation_info["reference"]) and mutation_info["length"] > 1:
+                mutation_info["type"] = "MNV"
+        return mutation_info
+
+    def _find_parent_sites(self, lineage: str, lineage_constellation: str):
+        """
+        Include for each constellation also the mutations present up in the phylogenetic tree.
+        """
+        parent = lineage_constellation[lineage].get("parent_lineage", None)
+        sites = lineage_constellation[lineage].get("lineage_mutations")
+        if parent is None:
+            return sites
+        else:
+            sites.extend([x for x in self._find_parent_sites(parent, lineage_constellation) if x not in sites])
+        return sites
 
     def _find_constellation_files(self):
         """
@@ -78,6 +205,8 @@ class LineageAnnotationsLoader:
             # These calls are incompatible with the scorpio constellation
             incompatible_lineage_calls = set(data["variant"].get("incompatible_lineage_calls", set()))
             pangolin_lineage_list = pangolin_lineage_list - incompatible_lineage_calls
+            lineage_mutations = [self._parse_mutation_sites(x) for x in data["sites"]]
+            lineage_mutations = [x for x in lineage_mutations if x is not None]
             lineage_constellation[constellation_label] = {
                 "pangolin_lineage_list": pangolin_lineage_list,
                 "who_label": who_label,
@@ -87,15 +216,20 @@ class LineageAnnotationsLoader:
                 "variant_of_concern": variant_of_concern,
                 "variant_under_investigation": variant_under_investigation,
                 "tags": tags,
-                "parent_lineage_id": parent_lineage_id
+                "parent_lineage_id": parent_lineage_id,
+                "lineage_mutations": lineage_mutations
             }
         return lineage_constellation
 
-    def _fill_lineage_table(self, lineage_constellation):
+    def _fill_lineage_mutation_table(self, lineage_constellation: dict):
         """
         Store constellation information in database
         """
         count_lineages = 0
+        count_mutations = 0
+        all_mutations = []
+        seen_mutations = set()
+
         # Get a list of pangolin lineage ids with a PHE label
         lineages_with_phe = [y.get("pangolin_lineage_list") for x, y in lineage_constellation.items()
                              if y.get("phe_label")]
@@ -128,9 +262,62 @@ class LineageAnnotationsLoader:
                 self.session.add(lineage)
                 self.session.commit()
                 count_lineages += 1
+            # Store mutations in dict
+            for this_mut in annotation["lineage_mutations"]:
+                if this_mut["level"] != "aa":
+                    continue
+                if this_mut["variant_id"] not in seen_mutations:
+                    seen_mutations.add(this_mut["variant_id"])
+                    all_mutations.append(this_mut)
         logger.info("Loaded into the database {} lineages".format(count_lineages))
+
+        # Store mutations in database
+        for this_mut in all_mutations:
+            # Skip variants on nucleotide level for now
+            mutation = LineageDefiningVariants(
+                variant_id=this_mut["variant_id"],
+                variant_type=this_mut["type"],
+                protein=this_mut["protein"],
+                position=this_mut["position"],
+                reference=this_mut["reference"],
+                alternate=this_mut["alternate"],
+                ambiguous_alternate=this_mut["ambiguous_alternate"]
+            )
+            self.session.add(mutation)
+            self.session.commit()
+            count_mutations += 1
+        logger.info("Loaded into the database {} mutations".format(count_mutations))
+
+    def _fill_relation_ship_table(self, lineage_constellation):
+        """
+        Store lineage/mutation N:M relationships
+        """
+        count_relationship = 0
+        mutation_lineage_mapping = {}
+        for constellation, annotation in lineage_constellation.items():
+            # Include mutations from parent lineages as well
+            all_mutations_of_lineage = self._find_parent_sites(constellation, lineage_constellation)
+            for mut in all_mutations_of_lineage:
+                if mut not in mutation_lineage_mapping:
+                    mutation_lineage_mapping[mut["site"]] = annotation["pangolin_lineage_list"]
+                else:
+                    # Create union of pango lineages with the mutation
+                    mutation_lineage_mapping[mut["site"]] |= annotation["pangolin_lineage_list"]
+
+        for variant_id, lineages in mutation_lineage_mapping.items():
+            for pango_lineage_id in lineages:
+                lineage_variant = LineageVariant(
+                    pango_lineage_id=pango_lineage_id,
+                    variant_id=variant_id
+                )
+                self.session.add(lineage_variant)
+                self.session.commit()
+                count_relationship += 1
+        logger.info("Loaded into the database {} lineage-variant relationships".format(count_relationship))
 
     def load_data(self):
         # Fill lineage annotation table
         lineage_constellation = self._read_constellation_files()
-        self._fill_lineage_table(lineage_constellation)
+        self._fill_lineage_mutation_table(lineage_constellation)
+        #self._fill_mutation_table(lineage_constellation)
+        #self._fill_relation_ship_table(lineage_constellation)

--- a/covigator/references/lineage_annotation.py
+++ b/covigator/references/lineage_annotation.py
@@ -511,7 +511,7 @@ class LineageAnnotationsLoader:
             match = re.match(snp_pattern, this_mut[1])
             if not match:
                 logger.warning("Could not parse the following site definition: {}".format(variant_string))
-                return [None]
+                return []
             hgvs = self.get_hgvs_from_nuc_snp({"genomic_position": int(match[2]), "reference": match[1],
                                                "alternate": match[3]})
             mutation_list.append(self._parse_nucleotide_level_snp(variant_string, hgvs))
@@ -520,7 +520,7 @@ class LineageAnnotationsLoader:
             match = re.match(aa_mutation, this_mut[1])
             if not match:
                 logger.warning("Could not parse the following site definition: {}".format(variant_string))
-                return [None]
+                return []
             protein = LineageAnnotationsLoader.protein_mapping.get(this_mut[0])
             reference = match[1]
             alternate = match[3]
@@ -616,8 +616,7 @@ class LineageAnnotationsLoader:
             # These calls are incompatible with the scorpio constellation
             incompatible_lineage_calls = set(data["variant"].get("incompatible_lineage_calls", set()))
             pangolin_lineage_list = pangolin_lineage_list - incompatible_lineage_calls
-            lineage_mutations = [self._parse_mutation_sites(x) for x in data["sites"]]
-            lineage_mutations = [mut for x in lineage_mutations for mut in x if mut is not None]
+            lineage_mutations = [mut for site in [self._parse_mutation_sites(x) for x in data["sites"]] for mut in site]
             lineage_constellation[constellation_label] = {
                 "pangolin_lineage_list": pangolin_lineage_list,
                 "who_label": who_label,

--- a/covigator/tests/unit_tests/test_database_initialisation.py
+++ b/covigator/tests/unit_tests/test_database_initialisation.py
@@ -126,8 +126,6 @@ class DatabaseInitialisationTests(AbstractTest):
                     self.assertTrue(
                         all([x in valid_protein.letters for x in d.reference])
                     )
-                    # For proteomic level deletions alternate is always "del"
-                    self.assertTrue(d.alternate == "del")
                 else:
                     # Add stop_lost / stop_gained to valid alphabet letters
                     self.assertTrue(d.reference in valid_protein.letters + "*")
@@ -137,7 +135,6 @@ class DatabaseInitialisationTests(AbstractTest):
                 self.assertTrue(
                     all([x in valid_nucleotide.letters for x in d.reference])
                 )
-                print(d.alternate)
                 self.assertTrue(
                     all([x in valid_nucleotide.letters for x in d.alternate])
                 )

--- a/covigator/tests/unit_tests/test_database_initialisation.py
+++ b/covigator/tests/unit_tests/test_database_initialisation.py
@@ -121,11 +121,8 @@ class DatabaseInitialisationTests(AbstractTest):
             self.assertIsNotNone(d.variant_level)
             self.assertIsNotNone(d.position)
             # Check type of reference and alternate
-            # Not working why?
-            # if d.variant_level == VariantLevel.PROTEOMIC.name:
-            if d.variant_level == "PROTEOMIC":
-                if d.variant_type == "DELETION":
-                # if d.variant_type == VariantType.DELETION.name:
+            if d.variant_level == VariantLevel.PROTEOMIC:
+                if d.variant_type == VariantType.DELETION:
                     self.assertTrue(
                         all([x in valid_protein.letters for x in d.reference])
                     )

--- a/covigator/tests/unit_tests/test_database_initialisation.py
+++ b/covigator/tests/unit_tests/test_database_initialisation.py
@@ -1,9 +1,11 @@
 from covigator.database.database import Database
 from covigator.database.model import Gene, get_table_versioned_name, Conservation, Domain, Lineages, \
-    LineageDefiningVariants, LineageVariant
+    LineageDefiningVariants, LineageVariant, VariantType, VariantLevel
 import pandas as pd
 from covigator.configuration import Configuration
 from covigator.tests.unit_tests.abstract_test import AbstractTest
+from Bio.Alphabet.IUPAC import protein as valid_protein
+from Bio.Alphabet.IUPAC import unambiguous_dna as valid_nucleotide
 
 
 class DatabaseInitialisationTests(AbstractTest):
@@ -117,6 +119,26 @@ class DatabaseInitialisationTests(AbstractTest):
             self.assertIsNotNone(d.alternate)
             self.assertIsNotNone(d.variant_type)
             self.assertIsNotNone(d.position)
+            # Check type of reference and alternate
+            if d.variant_level == VariantLevel.PROTEOMIC.name:
+                if d.variant_type == VariantType.DELETION.name:
+                    self.assertTrue(
+                        all([x in valid_protein.letters for x in d.reference])
+                    )
+                    # For proteomic level deletions alternate is always "del"
+                    self.assertTrue(d.alternate == "del")
+                else:
+                    # Add stop_lost / stop_gained to valid alphabet letters
+                    self.assertTrue(d.reference in valid_protein.letters + "*")
+                    self.assertTrue(d.alternate in valid_protein.letters + "*")
+            # Check nucleotide level SNVs and Deletions
+            else:
+                self.assertTrue(
+                    all([x in valid_nucleotide.letters for x in d.reference])
+                )
+                self.assertTrue(
+                    all([x in valid_nucleotide.letters for x in d.alternate])
+                )
 
         # Test that mutations are parsed and stored for a lineage correctly
         query_delta = session.query(LineageVariant).filter(LineageVariant.pango_lineage_id == "B.1.617.2")

--- a/covigator/tests/unit_tests/test_database_initialisation.py
+++ b/covigator/tests/unit_tests/test_database_initialisation.py
@@ -1,5 +1,6 @@
 from covigator.database.database import Database
-from covigator.database.model import Gene, get_table_versioned_name, Conservation, Domain, Lineages
+from covigator.database.model import Gene, get_table_versioned_name, Conservation, Domain, Lineages, \
+    LineageDefiningVariants, LineageVariant
 import pandas as pd
 from covigator.configuration import Configuration
 from covigator.tests.unit_tests.abstract_test import AbstractTest
@@ -104,3 +105,31 @@ class DatabaseInitialisationTests(AbstractTest):
         self.assertEqual(voc_lineages.shape[0], 9)
         who_labels = set(voc_lineages["who_label"].dropna())
         self.assertEqual(len(who_labels), 5)
+
+    def test_lineage_mutation_initialisation(self):
+        database = Database(test=True, config=self.config)
+        session = database.get_database_session()
+        self.assertGreater(session.query(LineageDefiningVariants).count(), 0)
+        lineage_variants = session.query(LineageDefiningVariants).all()
+        for d in lineage_variants:
+            self.assertIsNotNone(d.variant_id)
+            self.assertIsNotNone(d.reference)
+            self.assertIsNotNone(d.alternate)
+            self.assertIsNotNone(d.variant_type)
+            self.assertIsNotNone(d.position)
+
+        # Test that mutations are parsed and stored for a lineage correctly
+        query_delta = session.query(LineageVariant).filter(LineageVariant.pango_lineage_id == "B.1.617.2")
+        query_delta = pd.read_sql(query_delta.statement, session.bind)
+        self.assertEqual(query_delta.shape[1], 14)
+
+        # Test that parental mutations are parsed and stored correctly
+        query_ay42 = session.query(LineageVariant).filter(LineageVariant.pango_lineage_id == "AY.4.2")
+        query_ay42 = pd.read_sql(query_ay42.statement, session.bind)
+        self.assertEqual(query_ay42.shape[1], 35)
+
+        query_ay4 = session.query(LineageVariant).filter(LineageVariant.pango_lineage_id == "AY.4")
+        query_ay4 = pd.read_sql(query_ay4.statement, session.bind)
+        self.assertEqual(query_ay4.shape[1], 32)
+        # Test that mutations from parent lineages are all present
+        self.assertTrue(all([x in query_ay42.variant_id.values for x in query_ay4.variant_id]))

--- a/covigator/tests/unit_tests/test_database_initialisation.py
+++ b/covigator/tests/unit_tests/test_database_initialisation.py
@@ -121,15 +121,15 @@ class DatabaseInitialisationTests(AbstractTest):
         # Test that mutations are parsed and stored for a lineage correctly
         query_delta = session.query(LineageVariant).filter(LineageVariant.pango_lineage_id == "B.1.617.2")
         query_delta = pd.read_sql(query_delta.statement, session.bind)
-        self.assertEqual(query_delta.shape[1], 14)
+        self.assertEqual(query_delta.shape[0], 14)
 
         # Test that parental mutations are parsed and stored correctly
         query_ay42 = session.query(LineageVariant).filter(LineageVariant.pango_lineage_id == "AY.4.2")
         query_ay42 = pd.read_sql(query_ay42.statement, session.bind)
-        self.assertEqual(query_ay42.shape[1], 35)
+        self.assertEqual(query_ay42.shape[0], 35)
 
         query_ay4 = session.query(LineageVariant).filter(LineageVariant.pango_lineage_id == "AY.4")
         query_ay4 = pd.read_sql(query_ay4.statement, session.bind)
-        self.assertEqual(query_ay4.shape[1], 32)
-        # Test that mutations from parent lineages are all present
+        self.assertEqual(query_ay4.shape[0], 32)
+        # Test that mutations from parent lineage(s) are all present
         self.assertTrue(all([x in query_ay42.variant_id.values for x in query_ay4.variant_id]))

--- a/covigator/tests/unit_tests/test_database_initialisation.py
+++ b/covigator/tests/unit_tests/test_database_initialisation.py
@@ -118,10 +118,14 @@ class DatabaseInitialisationTests(AbstractTest):
             self.assertIsNotNone(d.reference)
             self.assertIsNotNone(d.alternate)
             self.assertIsNotNone(d.variant_type)
+            self.assertIsNotNone(d.variant_level)
             self.assertIsNotNone(d.position)
             # Check type of reference and alternate
-            if d.variant_level == VariantLevel.PROTEOMIC.name:
-                if d.variant_type == VariantType.DELETION.name:
+            # Not working why?
+            # if d.variant_level == VariantLevel.PROTEOMIC.name:
+            if d.variant_level == "PROTEOMIC":
+                if d.variant_type == "DELETION":
+                # if d.variant_type == VariantType.DELETION.name:
                     self.assertTrue(
                         all([x in valid_protein.letters for x in d.reference])
                     )

--- a/covigator/tests/unit_tests/test_database_initialisation.py
+++ b/covigator/tests/unit_tests/test_database_initialisation.py
@@ -140,6 +140,7 @@ class DatabaseInitialisationTests(AbstractTest):
                 self.assertTrue(
                     all([x in valid_nucleotide.letters for x in d.reference])
                 )
+                print(d.alternate)
                 self.assertTrue(
                     all([x in valid_nucleotide.letters for x in d.alternate])
                 )

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -163,4 +163,22 @@ class LineageAnnotationTest(AbstractTest):
         self.assertTrue(fake_lineage_a_mutations[0] in b_sites)
         self.assertTrue(fake_lineage_a_mutations[1] in b_sites)
 
+    def test_is_frameshift(self):
+        self.assertTrue(LineageAnnotationsLoader.is_frameshift(2))
+        self.assertFalse(LineageAnnotationsLoader.is_frameshift(3))
+
+    def test_get_protein_position(self):
+        self.assertTrue(LineageAnnotationsLoader.get_protein_position(1) == 1)
+        self.assertTrue(LineageAnnotationsLoader.get_protein_position(2) == 1)
+        self.assertTrue(LineageAnnotationsLoader.get_protein_position(4) == 2)
+        self.assertTrue(LineageAnnotationsLoader.get_protein_position(10) == 4)
+
+    def test_get_last_position_of_deletion(self):
+        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 2) == 100)
+        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 3) == 101)
+        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 4) == 100)
+        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 6) == 102)
+        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 9) == 103)
+
+
 

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -20,7 +20,7 @@ class LineageAnnotationTest(AbstractTest):
             self.assertIsNone(x[0])
 
     def test_get_hgvs_from_nuc_snp(self):
-        # Test if different SNP classes
+        # Test for different SNP classes
         missense_snp = {"genomic_position": 21765, "reference": "T", "alternate": "C"}
         synonymous_snp = {"genomic_position": 913, "reference": "C", "alternate": "T"}
         intergenic_snp = {"genomic_position": 240, "reference": "C", "alternate": "T"}
@@ -39,6 +39,7 @@ class LineageAnnotationTest(AbstractTest):
         )
 
     def test_get_hgvs_from_nuc_deletion(self):
+        # Test deletions with different effects
         # 21990:TTTA>T = p.Y144del
         normal_deletion = {"genomic_position": 21990, "length": 3}
         # 21990:TTTATTACCA>T = p.Y144_H146del
@@ -96,7 +97,7 @@ class LineageAnnotationTest(AbstractTest):
         self.assertTrue(parsed_site[0]["variant_id"] == "N:R203K")
         self.assertTrue(parsed_site[1]["variant_id"] == "N:G204R")
 
-    def _create_constellation_pango_mapping(self):
+    def test_create_constellation_pango_mapping(self):
         fake_lineage_constellation = {
             "A": {"pangolin_lineage_list": set("A.1"), "parent_lineage_id": None},
             "B": {"pangolin_lineage_list": set("B.1"), "parent_lineage_id": "A.1"}}
@@ -114,7 +115,8 @@ class LineageAnnotationTest(AbstractTest):
                   "lineage_mutations": [{"variant_id": 3}, {"variant_id": 4}]}
         }
         b_sites = self.loader._find_parent_sites("B",
-            fake_lineage_constellation, LineageAnnotationsLoader._create_constellation_pango_mapping(fake_lineage_constellation))
+            fake_lineage_constellation,
+            LineageAnnotationsLoader._create_constellation_pango_mapping(fake_lineage_constellation))
         self.assertIsNotNone(b_sites)
         self.assertEqual(len(b_sites), 4)
         # Test that parent sites are returned

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -164,21 +164,50 @@ class LineageAnnotationTest(AbstractTest):
         self.assertTrue(fake_lineage_a_mutations[1] in b_sites)
 
     def test_is_frameshift(self):
-        self.assertTrue(LineageAnnotationsLoader.is_frameshift(2))
-        self.assertFalse(LineageAnnotationsLoader.is_frameshift(3))
+        self.assertTrue(LineageAnnotationsLoader._is_frameshift(2))
+        self.assertFalse(LineageAnnotationsLoader._is_frameshift(3))
 
     def test_get_protein_position(self):
-        self.assertTrue(LineageAnnotationsLoader.get_protein_position(1) == 1)
-        self.assertTrue(LineageAnnotationsLoader.get_protein_position(2) == 1)
-        self.assertTrue(LineageAnnotationsLoader.get_protein_position(4) == 2)
-        self.assertTrue(LineageAnnotationsLoader.get_protein_position(10) == 4)
+        self.assertTrue(LineageAnnotationsLoader._get_protein_position(1) == 1)
+        self.assertTrue(LineageAnnotationsLoader._get_protein_position(2) == 1)
+        self.assertTrue(LineageAnnotationsLoader._get_protein_position(4) == 2)
+        self.assertTrue(LineageAnnotationsLoader._get_protein_position(10) == 4)
 
     def test_get_last_position_of_deletion(self):
-        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 2) == 100)
-        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 3) == 101)
-        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 4) == 100)
-        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 6) == 102)
-        self.assertTrue(LineageAnnotationsLoader.get_last_position_of_deletion(100, 9) == 103)
+        self.assertTrue(LineageAnnotationsLoader._get_last_position_of_deletion(100, 2) == 100)
+        self.assertTrue(LineageAnnotationsLoader._get_last_position_of_deletion(100, 3) == 101)
+        self.assertTrue(LineageAnnotationsLoader._get_last_position_of_deletion(100, 4) == 100)
+        self.assertTrue(LineageAnnotationsLoader._get_last_position_of_deletion(100, 6) == 102)
+        self.assertTrue(LineageAnnotationsLoader._get_last_position_of_deletion(100, 9) == 103)
+
+    def test_get_frameshift_hgvs(self):
+        hgvs = LineageAnnotationsLoader._get_frameshift_hgvs("A", 1)
+        self.assertIsNotNone(hgvs)
+        self.assertTrue(hgvs == "p.1Afs")
+
+    def test_get_insdel_hgvs(self):
+        hgvs = LineageAnnotationsLoader._get_insdel_hgvs("A", 1, "V", 2, "G")
+        self.assertIsNotNone(hgvs)
+        self.assertTrue(hgvs == "p.A1_V2delinsG")
+
+    def test_get_deletion_hgvs(self):
+        hgvs = LineageAnnotationsLoader._get_deletion_hgvs("A", 1, "V", 2)
+        self.assertIsNotNone(hgvs)
+        self.assertTrue(hgvs == "p.A1_V2del")
+        hgvs = LineageAnnotationsLoader._get_deletion_hgvs("A", 1, None, 1)
+        self.assertIsNotNone(hgvs)
+        self.assertTrue(hgvs == "p.A1del")
+
+    def test_generate_variant_id(self):
+        # Test nucleotide level variant id
+        var_id = LineageAnnotationsLoader._generate_variant_id(None, 1, "A", "G")
+        self.assertIsNotNone(var_id)
+        self.assertTrue(var_id == "1:A>G")
+        # Test proteomic variant id
+        var_id = LineageAnnotationsLoader._generate_variant_id("S", 144, "G", "R")
+        self.assertIsNotNone(var_id)
+        self.assertTrue(var_id == "S:G144R")
+
 
 
 

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -14,7 +14,7 @@ class LineageAnnotationTest(AbstractTest):
         intergenic_locations = [265, 21556]
         for loc in gene_locations:
             x = self.loader.find_gene(loc)
-            self.assertEqual(x, ['ORF1ab', 266,  21555])
+            self.assertEqual(x, ('ORF1ab', 266,  21555))
         for loc in intergenic_locations:
             x = self.loader.find_gene(loc)
             self.assertIsNone(x[0])
@@ -27,15 +27,18 @@ class LineageAnnotationTest(AbstractTest):
 
         x = self.loader.get_hgvs_from_nuc_snp(missense_snp)
         self.assertEqual(
-            x, {'hgvs_p': 'p.I68T', 'position': 68, 'reference': 'I', 'alternate': 'T', 'annotation': 'missense'}
+            x, {'hgvs_p': 'p.I68T', 'position': 68, 'reference': 'I', 'alternate': 'T',
+                'annotation': 'missense_variant', 'protein': 'S'}
         )
         x = self.loader.get_hgvs_from_nuc_snp(synonymous_snp)
         self.assertEqual(
-            x, {'hgvs_p': 'p.S216S', 'position': 216, 'reference': 'S', 'alternate': 'S', 'annotation': 'synonymous'}
+            x, {'hgvs_p': 'p.S216S', 'position': 216, 'reference': 'S', 'alternate': 'S',
+                'annotation': 'synonymous_variant', 'protein': 'ORF1ab'}
         )
         x = self.loader.get_hgvs_from_nuc_snp(intergenic_snp)
         self.assertEqual(
-            x, {'hgvs_p': None, 'position': 240, 'reference': 'C', 'alternate': 'T', 'annotation': 'intergenic'}
+            x, {'hgvs_p': None, 'position': 240, 'reference': 'C', 'alternate': 'T',
+                'annotation': 'intergenic_variant', 'protein': None}
         )
 
     def test_get_hgvs_from_nuc_deletion(self):
@@ -55,27 +58,33 @@ class LineageAnnotationTest(AbstractTest):
 
         self.assertEqual(
             self.loader.get_hgvs_from_nuc_deletion(normal_deletion),
-            {'hgvs_p': 'p.Y144del', 'reference': 'Y', 'alternate': 'del', 'position': 144}
+            {'hgvs_p': 'p.Y144del', 'reference': 'Y', 'alternate': 'del',
+             'position': 144, "annotation": "conservative_inframe_deletion", "protein": "S"}
         )
         self.assertEqual(
             self.loader.get_hgvs_from_nuc_deletion(normal_deletion_long),
-            {'hgvs_p': 'p.Y144_H146del', 'reference': 'YYH', 'alternate': 'del', 'position': 144}
+            {'hgvs_p': 'p.Y144_H146del', 'reference': 'YYH', 'alternate': 'del',
+             'position': 144, "annotation": "disruptive_inframe_deletion", "protein": "S"}
         )
         self.assertEqual(
             self.loader.get_hgvs_from_nuc_deletion(normal_deletion_long_2),
-            {'hgvs_p': 'p.F157_R158del', 'reference': 'FR', 'alternate': 'del', 'position': 157}
+            {'hgvs_p': 'p.F157_R158del', 'reference': 'FR', 'alternate': 'del',
+             'position': 157, "annotation": "disruptive_inframe_deletion", 'protein': "S"}
         )
         self.assertEqual(
             self.loader.get_hgvs_from_nuc_deletion(fs_deletion),
-            {'hgvs_p': 'p.Y144fs', 'reference': 'Y', 'alternate': 'del', 'position': 144}
+            {'hgvs_p': 'p.Y144fs', 'reference': 'Y', 'alternate': 'del',
+             'position': 144, 'annotation': 'frameshift_variant', 'protein': 'S'}
         )
         self.assertEqual(
             self.loader.get_hgvs_from_nuc_deletion(insdel_deletion),
-            {'hgvs_p': 'p.Y144_S155delinsC', 'reference': 'YYHKNNKSWMES', 'alternate': 'del', 'position': 144}
+            {'hgvs_p': 'p.Y144_S155delinsC', 'reference': 'YYHKNNKSWMES', 'alternate': 'del',
+             'position': 144, "annotation": "disruptive_inframe_deletion", "protein": "S"}
         )
         self.assertEqual(
             self.loader.get_hgvs_from_nuc_deletion(insdel_deletion_2),
-            {'hgvs_p': 'p.L24_Y28delinsF', 'reference': 'LPPAY', 'alternate': 'del', 'position': 24}
+            {'hgvs_p': 'p.L24_Y28delinsF', 'reference': 'LPPAY', 'alternate': 'del',
+             'position': 24, "annotation": "disruptive_inframe_deletion", "protein": "S"}
         )
 
     def test_parse_mutation_sites(self):

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -14,7 +14,7 @@ class LineageAnnotationTest(AbstractTest):
         intergenic_locations = [265, 21556]
         for loc in gene_locations:
             x = self.loader.find_gene(loc)
-            self.assertEqual(x, ['ORF1ab', '266',  '21555'])
+            self.assertEqual(x, ['ORF1ab', 266,  21555])
         for loc in intergenic_locations:
             x = self.loader.find_gene(loc)
             self.assertIsNone(x[0])
@@ -35,7 +35,7 @@ class LineageAnnotationTest(AbstractTest):
         )
         x = self.loader.get_hgvs_from_nuc_snp(intergenic_snp)
         self.assertEqual(
-            x, {'hgvs_p': None, 'position': 240, 'reference': 'T', 'alternate': 'C', 'annotation': 'intergenic'}
+            x, {'hgvs_p': None, 'position': 240, 'reference': 'C', 'alternate': 'T', 'annotation': 'intergenic'}
         )
 
     def test_get_hgvs_from_nuc_deletion(self):

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -99,8 +99,8 @@ class LineageAnnotationTest(AbstractTest):
 
     def test_create_constellation_pango_mapping(self):
         fake_lineage_constellation = {
-            "A": {"pangolin_lineage_list": set("A.1"), "parent_lineage_id": None},
-            "B": {"pangolin_lineage_list": set("B.1"), "parent_lineage_id": "A.1"}}
+            "A": {"pangolin_lineage_list": set(["A.1"]), "parent_lineage_id": None},
+            "B": {"pangolin_lineage_list": set(["B.1"]), "parent_lineage_id": "A.1"}}
         mapping = self.loader._create_constellation_pango_mapping(fake_lineage_constellation)
         self.assertIsInstance(fake_lineage_constellation, dict)
         self.assertEqual(len(mapping), 2)

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -118,12 +118,12 @@ class LineageAnnotationTest(AbstractTest):
         parsed_site = self.loader._parse_mutation_sites("nuc:C16176T")
         self.assertIsNotNone(parsed_site)
         self.assertEqual(len(parsed_site), 1)
-        self.assertIsInstance(parsed_site[0], Hgvs)
+        self.assertIsInstance(parsed_site[0], MutationInfo)
 
         parsed_site = self.loader._parse_mutation_sites("spike:D614G")
         self.assertIsNotNone(parsed_site)
         self.assertEqual(len(parsed_site), 1)
-        self.assertIsInstance(parsed_site[0], Hgvs)
+        self.assertIsInstance(parsed_site[0], MutationInfo)
 
         # Test that grouped AA level mutation are split into separate mutations
         parsed_site = self.loader._parse_mutation_sites("n:RG203KR")

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -12,12 +12,16 @@ class LineageAnnotationTest(AbstractTest):
     def test_find_gene(self):
         gene_locations = [266, 13483]
         intergenic_locations = [265, 21556]
+        # Normal positions
         for loc in gene_locations:
             x = self.loader.find_gene(loc)
             self.assertEqual(x, ('ORF1ab', 266, 21555))
+        # Test intergenic positions and None case
         for loc in intergenic_locations:
             x = self.loader.find_gene(loc)
             self.assertIsNone(x[0])
+        x = self.loader.find_gene(None)
+        self.assertIsNone(x[0])
 
     def test_get_hgvs_from_nuc_snp(self):
         # Test for different SNP classes
@@ -91,7 +95,7 @@ class LineageAnnotationTest(AbstractTest):
         x = self.loader.get_hgvs_from_nuc_deletion(fs_deletion)
         self.assertTrue(x.hgvs_p == "p.Y144fs")
         self.assertTrue(x.reference == "Y")
-        self.assertTrue(x.alternate == "del")
+        self.assertTrue(x.alternate == "fs")
         self.assertTrue(x.position == 144)
         self.assertTrue(x.annotation == "frameshift_variant")
         self.assertTrue(x.protein == "S")
@@ -99,7 +103,7 @@ class LineageAnnotationTest(AbstractTest):
         x = self.loader.get_hgvs_from_nuc_deletion(insdel_deletion)
         self.assertTrue(x.hgvs_p == "p.Y144_S155delinsC")
         self.assertTrue(x.reference == "YYHKNNKSWMES")
-        self.assertTrue(x.alternate == "del")
+        self.assertTrue(x.alternate == "delinsC")
         self.assertTrue(x.position == 144)
         self.assertTrue(x.annotation == "disruptive_inframe_deletion")
         self.assertTrue(x.protein == "S")
@@ -107,7 +111,7 @@ class LineageAnnotationTest(AbstractTest):
         x = self.loader.get_hgvs_from_nuc_deletion(insdel_deletion_2)
         self.assertTrue(x.hgvs_p == "p.L24_Y28delinsF")
         self.assertTrue(x.reference == "LPPAY")
-        self.assertTrue(x.alternate == "del")
+        self.assertTrue(x.alternate == "delinsF")
         self.assertTrue(x.position == 24)
         self.assertTrue(x.annotation == "disruptive_inframe_deletion")
         self.assertTrue(x.protein == "S")

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -2,7 +2,7 @@ from covigator.database.database import Database
 from covigator.database.queries import Queries
 from covigator.configuration import Configuration
 from covigator.tests.unit_tests.abstract_test import AbstractTest
-from covigator.references.lineage_annotation import LineageAnnotationsLoader
+from covigator.references.lineage_annotation import LineageAnnotationsLoader, Hgvs, MutationInfo
 
 
 class LineageAnnotationTest(AbstractTest):
@@ -14,7 +14,7 @@ class LineageAnnotationTest(AbstractTest):
         intergenic_locations = [265, 21556]
         for loc in gene_locations:
             x = self.loader.find_gene(loc)
-            self.assertEqual(x, ('ORF1ab', 266,  21555))
+            self.assertEqual(x, ('ORF1ab', 266, 21555))
         for loc in intergenic_locations:
             x = self.loader.find_gene(loc)
             self.assertIsNone(x[0])
@@ -26,20 +26,28 @@ class LineageAnnotationTest(AbstractTest):
         intergenic_snp = {"genomic_position": 240, "reference": "C", "alternate": "T"}
 
         x = self.loader.get_hgvs_from_nuc_snp(missense_snp)
-        self.assertEqual(
-            x, {'hgvs_p': 'p.I68T', 'position': 68, 'reference': 'I', 'alternate': 'T',
-                'annotation': 'missense_variant', 'protein': 'S'}
-        )
+        self.assertTrue(x.hgvs_p == 'p.I68T')
+        self.assertTrue(x.position == 68)
+        self.assertTrue(x.reference == "I")
+        self.assertTrue(x.alternate == "T")
+        self.assertTrue(x.annotation == "missense_variant")
+        self.assertTrue(x.protein == "S")
+
         x = self.loader.get_hgvs_from_nuc_snp(synonymous_snp)
-        self.assertEqual(
-            x, {'hgvs_p': 'p.S216S', 'position': 216, 'reference': 'S', 'alternate': 'S',
-                'annotation': 'synonymous_variant', 'protein': 'ORF1ab'}
-        )
+        self.assertTrue(x.hgvs_p == 'p.S216S')
+        self.assertTrue(x.position == 216)
+        self.assertTrue(x.reference == "S")
+        self.assertTrue(x.alternate == "S")
+        self.assertTrue(x.annotation == "synonymous_variant")
+        self.assertTrue(x.protein == "ORF1ab")
+
         x = self.loader.get_hgvs_from_nuc_snp(intergenic_snp)
-        self.assertEqual(
-            x, {'hgvs_p': None, 'position': 240, 'reference': 'C', 'alternate': 'T',
-                'annotation': 'intergenic_variant', 'protein': None}
-        )
+        self.assertTrue(x.hgvs_p is None)
+        self.assertTrue(x.position == 240)
+        self.assertTrue(x.reference == "C")
+        self.assertTrue(x.alternate == "T")
+        self.assertTrue(x.annotation == "intergenic_variant")
+        self.assertTrue(x.protein is None)
 
     def test_get_hgvs_from_nuc_deletion(self):
         # Test deletions with different effects
@@ -56,55 +64,73 @@ class LineageAnnotationTest(AbstractTest):
         # 21633:TACCCCCTGCATA>T = p.L24_Y28delinsF
         insdel_deletion_2 = {"genomic_position": 21633, "length": 12}
 
-        self.assertEqual(
-            self.loader.get_hgvs_from_nuc_deletion(normal_deletion),
-            {'hgvs_p': 'p.Y144del', 'reference': 'Y', 'alternate': 'del',
-             'position': 144, "annotation": "conservative_inframe_deletion", "protein": "S"}
-        )
-        self.assertEqual(
-            self.loader.get_hgvs_from_nuc_deletion(normal_deletion_long),
-            {'hgvs_p': 'p.Y144_H146del', 'reference': 'YYH', 'alternate': 'del',
-             'position': 144, "annotation": "disruptive_inframe_deletion", "protein": "S"}
-        )
-        self.assertEqual(
-            self.loader.get_hgvs_from_nuc_deletion(normal_deletion_long_2),
-            {'hgvs_p': 'p.F157_R158del', 'reference': 'FR', 'alternate': 'del',
-             'position': 157, "annotation": "disruptive_inframe_deletion", 'protein': "S"}
-        )
-        self.assertEqual(
-            self.loader.get_hgvs_from_nuc_deletion(fs_deletion),
-            {'hgvs_p': 'p.Y144fs', 'reference': 'Y', 'alternate': 'del',
-             'position': 144, 'annotation': 'frameshift_variant', 'protein': 'S'}
-        )
-        self.assertEqual(
-            self.loader.get_hgvs_from_nuc_deletion(insdel_deletion),
-            {'hgvs_p': 'p.Y144_S155delinsC', 'reference': 'YYHKNNKSWMES', 'alternate': 'del',
-             'position': 144, "annotation": "disruptive_inframe_deletion", "protein": "S"}
-        )
-        self.assertEqual(
-            self.loader.get_hgvs_from_nuc_deletion(insdel_deletion_2),
-            {'hgvs_p': 'p.L24_Y28delinsF', 'reference': 'LPPAY', 'alternate': 'del',
-             'position': 24, "annotation": "disruptive_inframe_deletion", "protein": "S"}
-        )
+        x = self.loader.get_hgvs_from_nuc_deletion(normal_deletion)
+        self.assertTrue(x.hgvs_p == "p.Y144del")
+        self.assertTrue(x.reference == "Y")
+        self.assertTrue(x.alternate == "del")
+        self.assertTrue(x.position == 144)
+        self.assertTrue(x.annotation == "conservative_inframe_deletion")
+        self.assertTrue(x.protein == "S")
+
+        x = self.loader.get_hgvs_from_nuc_deletion(normal_deletion_long)
+        self.assertTrue(x.hgvs_p == "p.Y144_H146del")
+        self.assertTrue(x.reference == "YYH")
+        self.assertTrue(x.alternate == "del")
+        self.assertTrue(x.position == 144)
+        self.assertTrue(x.annotation == "disruptive_inframe_deletion")
+        self.assertTrue(x.protein == "S")
+
+        x = self.loader.get_hgvs_from_nuc_deletion(normal_deletion_long_2)
+        self.assertTrue(x.hgvs_p == "p.F157_R158del")
+        self.assertTrue(x.reference == "FR")
+        self.assertTrue(x.alternate == "del")
+        self.assertTrue(x.position == 157)
+        self.assertTrue(x.annotation == "disruptive_inframe_deletion")
+        self.assertTrue(x.protein == "S")
+
+        x = self.loader.get_hgvs_from_nuc_deletion(fs_deletion)
+        self.assertTrue(x.hgvs_p == "p.Y144fs")
+        self.assertTrue(x.reference == "Y")
+        self.assertTrue(x.alternate == "del")
+        self.assertTrue(x.position == 144)
+        self.assertTrue(x.annotation == "frameshift_variant")
+        self.assertTrue(x.protein == "S")
+
+        x = self.loader.get_hgvs_from_nuc_deletion(insdel_deletion)
+        self.assertTrue(x.hgvs_p == "p.Y144_S155delinsC")
+        self.assertTrue(x.reference == "YYHKNNKSWMES")
+        self.assertTrue(x.alternate == "del")
+        self.assertTrue(x.position == 144)
+        self.assertTrue(x.annotation == "disruptive_inframe_deletion")
+        self.assertTrue(x.protein == "S")
+
+        x = self.loader.get_hgvs_from_nuc_deletion(insdel_deletion_2)
+        self.assertTrue(x.hgvs_p == "p.L24_Y28delinsF")
+        self.assertTrue(x.reference == "LPPAY")
+        self.assertTrue(x.alternate == "del")
+        self.assertTrue(x.position == 24)
+        self.assertTrue(x.annotation == "disruptive_inframe_deletion")
+        self.assertTrue(x.protein == "S")
+
 
     def test_parse_mutation_sites(self):
         # Test that pangolin mutation definitions are parsed correctly
         parsed_site = self.loader._parse_mutation_sites("nuc:C16176T")
         self.assertIsNotNone(parsed_site)
         self.assertEqual(len(parsed_site), 1)
-        self.assertIsInstance(parsed_site[0], dict)
+        self.assertIsInstance(parsed_site[0], Hgvs)
 
         parsed_site = self.loader._parse_mutation_sites("spike:D614G")
         self.assertIsNotNone(parsed_site)
         self.assertEqual(len(parsed_site), 1)
-        self.assertIsInstance(parsed_site[0], dict)
+        self.assertIsInstance(parsed_site[0], Hgvs)
 
         # Test that grouped AA level mutation are split into separate mutations
         parsed_site = self.loader._parse_mutation_sites("n:RG203KR")
         self.assertIsNotNone(parsed_site)
         self.assertEqual(len(parsed_site), 2)
-        self.assertTrue(parsed_site[0]["variant_id"] == "N:R203K")
-        self.assertTrue(parsed_site[1]["variant_id"] == "N:G204R")
+        self.assertTrue(parsed_site[0].variant_id == "N:R203K")
+        self.assertTrue(parsed_site[1].variant_id == "N:G204R")
 
     def test_create_constellation_pango_mapping(self):
         fake_lineage_constellation = {
@@ -115,13 +141,18 @@ class LineageAnnotationTest(AbstractTest):
         self.assertEqual(len(mapping), 2)
 
     def test_find_parent_sites(self):
+        fake_lineage_a_mutations = [Hgvs(hgvs_p=1, reference="A", alternate="T", position=1, annotation="A", protein="S"),
+                                    Hgvs(hgvs_p=2, reference="A", alternate="T", position=1, annotation="A", protein="S")]
+        fake_lineage_b_mutations = [Hgvs(hgvs_p=3, reference="A", alternate="T", position=1, annotation="A", protein="S"),
+                                    Hgvs(hgvs_p=4, reference="A", alternate="T", position=1, annotation="A", protein="S")]
+
         fake_lineage_constellation = {
             "A": {"pangolin_lineage_list": set(["A.1"]),
                   "parent_lineage_id": None,
-                  "lineage_mutations": [{"variant_id": 1}, {"variant_id": 2}]},
+                  "lineage_mutations": fake_lineage_a_mutations},
             "B": {"pangolin_lineage_list": set(["B.1"]),
                   "parent_lineage_id": "A.1",
-                  "lineage_mutations": [{"variant_id": 3}, {"variant_id": 4}]}
+                  "lineage_mutations": fake_lineage_b_mutations}
         }
         b_sites = self.loader._find_parent_sites("B",
             fake_lineage_constellation,
@@ -129,7 +160,7 @@ class LineageAnnotationTest(AbstractTest):
         self.assertIsNotNone(b_sites)
         self.assertEqual(len(b_sites), 4)
         # Test that parent sites are returned
-        self.assertTrue({"variant_id": 1} in b_sites)
-        self.assertTrue({"variant_id": 2} in b_sites)
+        self.assertTrue(fake_lineage_a_mutations[0] in b_sites)
+        self.assertTrue(fake_lineage_a_mutations[1] in b_sites)
 
 

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -8,71 +8,71 @@ from covigator.references.lineage_annotation import LineageAnnotationsLoader
 class LineageAnnotationTest(AbstractTest):
     def setUp(self) -> None:
         self.queries = Queries(session=self.session)
-
+        self.loader = LineageAnnotationsLoader(self.session)
     def test_find_gene(self):
         gene_locations = [266, 21555]
         intergenic_locations = [265, 21556]
         for loc in gene_locations:
-            x = LineageAnnotationsLoader.find_gene(loc)
+            x = self.loader.find_gene(loc)
             self.assertEqual(x, ['ORF1ab', '266',  '21555'])
         for loc in intergenic_locations:
-            x = LineageAnnotationsLoader.find_gene(loc)
+            x = self.loader.find_gene(loc)
             self.assertIsNone(x[0])
 
     def test_get_hgvs_from_nuc_snp(self):
         # Test if different SNP classes
-        missense_snp = {"genomic_position" : 21765 , "reference": "T", "alternate": "C"}
-        synonymous_snp = {"genomic_position" : 913, "reference": "C", "alternate": "T"}
+        missense_snp = {"genomic_position": 21765, "reference": "T", "alternate": "C"}
+        synonymous_snp = {"genomic_position": 913, "reference": "C", "alternate": "T"}
         intergenic_snp = {"genomic_position": 240, "reference": "C", "alternate": "T"}
 
-        x = LineageAnnotationsLoader.get_hgvs_from_nuc_snp(missense_snp)
+        x = self.loader.get_hgvs_from_nuc_snp(missense_snp)
         self.assertEqual(
             x, {'hgvs_p': 'p.I68T', 'position': 68, 'reference': 'I', 'alternate': 'T', 'annotation': 'missense'}
         )
-        x = LineageAnnotationsLoader.get_hgvs_from_nuc_snp(synonymous_snp)
+        x = self.loader.get_hgvs_from_nuc_snp(synonymous_snp)
         self.assertEqual(
             x, {'hgvs_p': 'p.S216S', 'position': 216, 'reference': 'S', 'alternate': 'S', 'annotation': 'synonymous'}
         )
-        x = LineageAnnotationsLoader.get_hgvs_from_nuc_snp(intergenic_snp)
+        x = self.loader.get_hgvs_from_nuc_snp(intergenic_snp)
         self.assertEqual(
             x, {'hgvs_p': None, 'position': 240, 'reference': 'T', 'alternate': 'C', 'annotation': 'intergenic'}
         )
 
     def test_get_hgvs_from_nuc_deletion(self):
         # 21990:TTTA>T = p.Y144del
-        normal_deletion = {"genomic_position" : 21990 , "length": 3}
+        normal_deletion = {"genomic_position": 21990, "length": 3}
         # 21990:TTTATTACCA>T = p.Y144_H146del
-        normal_deletion_long = {"genomic_position" : 21990 , "length": 9}
+        normal_deletion_long = {"genomic_position": 21990, "length": 9}
         # 21992:TA>T = p.Y144fs
-        fs_deletion =  {"genomic_position" : 21992 , "length": 2}
+        fs_deletion = {"genomic_position": 21992, "length": 2}
         # 21992:TATTACCACAAAAACAACAAAAGTTGGATGGAAA>T = p.Y144_S155delinsC
-        insdel_deletion = {"genomic_position" : 21992 , "length": 33}
+        insdel_deletion = {"genomic_position": 21992, "length": 33}
 
         self.assertEqual(
-            LineageAnnotationsLoader.get_hgvs_from_nuc_deletion(normal_deletion),
+            self.loader.get_hgvs_from_nuc_deletion(normal_deletion),
             {'hgvs_p': 'p.Y144del', 'reference': 'Y', 'alternate': 'del', 'position': 144}
         )
         self.assertEqual(
-            LineageAnnotationsLoader.get_hgvs_from_nuc_deletion(normal_deletion_long),
+            self.loader.get_hgvs_from_nuc_deletion(normal_deletion_long),
             {'hgvs_p': 'p.Y144_H146del', 'reference': 'YYH', 'alternate': 'del', 'position': 144}
         )
         self.assertEqual(
-            LineageAnnotationsLoader.get_hgvs_from_nuc_deletion(fs_deletion),
+            self.loader.get_hgvs_from_nuc_deletion(fs_deletion),
             {'hgvs_p': 'p.Y144fs', 'reference': 'Y', 'alternate': 'del', 'position': 144}
         )
         self.assertEqual(
-            LineageAnnotationsLoader.get_hgvs_from_nuc_deletion(insdel_deletion),
+            self.loader.get_hgvs_from_nuc_deletion(insdel_deletion),
             {'hgvs_p': 'p.Y144_S155delinsC', 'reference': 'YYHKNNKSWMES', 'alternate': 'del', 'position': 144}
         )
 
     def test_parse_mutation_sites(self):
         # Test that pangolin mutation definitions are parsed correctly
-        parsed_site = LineageAnnotationsLoader._parse_mutation_sites("nuc:C16176T")
+        parsed_site = self.loader._parse_mutation_sites("nuc:C16176T")
         self.assertIsNotNone(parsed_site)
         self.assertEqual(len(parsed_site), 1)
         self.assertIsInstance(parsed_site[0], dict)
         # Test that grouped AA level mutation are split into separate mutations
-        parsed_site = LineageAnnotationsLoader._parse_mutation_sites("n:RG203KR")
+        parsed_site = self.loader._parse_mutation_sites("n:RG203KR")
         self.assertIsNotNone(parsed_site)
         self.assertEqual(len(parsed_site), 2)
 
@@ -80,7 +80,7 @@ class LineageAnnotationTest(AbstractTest):
         fake_lineage_constellation = {
             "A": {"pango_lineage_list": set("A.1"), "parent_lineage_id": None},
             "B": {"pango_lineage_list": set("B.1"), "parent_lineage_id": "A.1"}}
-        mapping = LineageAnnotationsLoader._create_constellation_pango_mapping(fake_lineage_constellation)
+        mapping = self.loader._create_constellation_pango_mapping(fake_lineage_constellation)
         self.assertIsInstance(fake_lineage_constellation, dict)
         self.assertEqual(len(mapping), 2)
 
@@ -93,7 +93,7 @@ class LineageAnnotationTest(AbstractTest):
                   "parent_lineage_id": "A.1",
                   "lineage_mutations": [{"variant_id": 3}, {"variant_id": 4}]}
         }
-        b_sites = LineageAnnotationsLoader._find_parent_sites("B",
+        b_sites = self.loader._find_parent_sites("B",
             fake_lineage_constellation, LineageAnnotationsLoader._create_constellation_pango_mapping(fake_lineage_constellation))
         self.assertIsNotNone(b_sites)
         self.assertEqual(len(b_sites), 4)

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -183,7 +183,7 @@ class LineageAnnotationTest(AbstractTest):
     def test_get_frameshift_hgvs(self):
         hgvs = LineageAnnotationsLoader._get_frameshift_hgvs("A", 1)
         self.assertIsNotNone(hgvs)
-        self.assertTrue(hgvs == "p.1Afs")
+        self.assertTrue(hgvs == "p.A1fs")
 
     def test_get_insdel_hgvs(self):
         hgvs = LineageAnnotationsLoader._get_insdel_hgvs("A", 1, "V", 2, "G")

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -1,0 +1,100 @@
+from covigator.database.database import Database
+from covigator.database.queries import Queries
+from covigator.configuration import Configuration
+from covigator.tests.unit_tests.abstract_test import AbstractTest
+from covigator.references.lineage_annotation import LineageAnnotationsLoader
+
+
+class LineageAnnotationTest(AbstractTest):
+    def setUp(self) -> None:
+        self.queries = Queries(session=self.session)
+
+    def test_find_gene(self):
+        gene_locations = [266, 21555]
+        intergenic_locations = [265, 21556]
+        for loc in gene_locations:
+            x = LineageAnnotationsLoader.find_gene(loc)
+            self.assertEqual(x, ['ORF1ab', '266',  '21555'])
+        for loc in intergenic_locations:
+            x = LineageAnnotationsLoader.find_gene(loc)
+            self.assertIsNone(x[0])
+
+    def test_get_hgvs_from_nuc_snp(self):
+        # Test if different SNP classes
+        missense_snp = {"genomic_position" : 21765 , "reference": "T", "alternate": "C"}
+        synonymous_snp = {"genomic_position" : 913, "reference": "C", "alternate": "T"}
+        intergenic_snp = {"genomic_position": 240, "reference": "C", "alternate": "T"}
+
+        x = LineageAnnotationsLoader.get_hgvs_from_nuc_snp(missense_snp)
+        self.assertEqual(
+            x, {'hgvs_p': 'p.I68T', 'position': 68, 'reference': 'I', 'alternate': 'T', 'annotation': 'missense'}
+        )
+        x = LineageAnnotationsLoader.get_hgvs_from_nuc_snp(synonymous_snp)
+        self.assertEqual(
+            x, {'hgvs_p': 'p.S216S', 'position': 216, 'reference': 'S', 'alternate': 'S', 'annotation': 'synonymous'}
+        )
+        x = LineageAnnotationsLoader.get_hgvs_from_nuc_snp(intergenic_snp)
+        self.assertEqual(
+            x, {'hgvs_p': None, 'position': 240, 'reference': 'T', 'alternate': 'C', 'annotation': 'intergenic'}
+        )
+
+    def test_get_hgvs_from_nuc_deletion(self):
+        # 21990:TTTA>T = p.Y144del
+        normal_deletion = {"genomic_position" : 21990 , "length": 3}
+        # 21990:TTTATTACCA>T = p.Y144_H146del
+        normal_deletion_long = {"genomic_position" : 21990 , "length": 9}
+        # 21992:TA>T = p.Y144fs
+        fs_deletion =  {"genomic_position" : 21992 , "length": 2}
+        # 21992:TATTACCACAAAAACAACAAAAGTTGGATGGAAA>T = p.Y144_S155delinsC
+        insdel_deletion = {"genomic_position" : 21992 , "length": 33}
+
+        self.assertEqual(
+            LineageAnnotationsLoader.get_hgvs_from_nuc_deletion(normal_deletion),
+            {'hgvs_p': 'p.Y144del', 'reference': 'Y', 'alternate': 'del', 'position': 144}
+        )
+        self.assertEqual(
+            LineageAnnotationsLoader.get_hgvs_from_nuc_deletion(normal_deletion_long),
+            {'hgvs_p': 'p.Y144_H146del', 'reference': 'YYH', 'alternate': 'del', 'position': 144}
+        )
+        self.assertEqual(
+            LineageAnnotationsLoader.get_hgvs_from_nuc_deletion(fs_deletion),
+            {'hgvs_p': 'p.Y144fs', 'reference': 'Y', 'alternate': 'del', 'position': 144}
+        )
+        self.assertEqual(
+            LineageAnnotationsLoader.get_hgvs_from_nuc_deletion(insdel_deletion),
+            {'hgvs_p': 'p.Y144_S155delinsC', 'reference': 'YYHKNNKSWMES', 'alternate': 'del', 'position': 144}
+        )
+
+    def test_parse_mutation_sites(self):
+        # Test that pangolin mutation definitions are parsed correctly
+        parsed_site = LineageAnnotationsLoader._parse_mutation_sites("nuc:C16176T")
+        self.assertIsNotNone(parsed_site)
+        self.assertEqual(len(parsed_site), 1)
+        self.assertIsInstance(parsed_site[0], dict)
+        # Test that grouped AA level mutation are split into separate mutations
+        parsed_site = LineageAnnotationsLoader._parse_mutation_sites("n:RG203KR")
+        self.assertIsNotNone(parsed_site)
+        self.assertEqual(len(parsed_site), 2)
+
+    def _create_constellation_pango_mapping(self):
+        fake_lineage_constellation = {
+            "A": {"pango_lineage_list": set("A.1"), "parent_lineage_id": None},
+            "B": {"pango_lineage_list": set("B.1"), "parent_lineage_id": "A.1"}}
+        mapping = LineageAnnotationsLoader._create_constellation_pango_mapping(fake_lineage_constellation)
+        self.assertIsInstance(fake_lineage_constellation, dict)
+        self.assertEqual(len(mapping), 2)
+
+    def test_find_parent_sites(self):
+        fake_lineage_constellation = {
+            "A": {"pango_lineage_list": set("A.1"),
+                  "parent_lineage_id": None,
+                  "lineage_mutations": [{"variant_id": 1}, {"variant_id": 2}]},
+            "B": {"pango_lineage_list": set("B.1"),
+                  "parent_lineage_id": "A.1",
+                  "lineage_mutations": [{"variant_id": 3}, {"variant_id": 4}]}
+        }
+        b_sites = LineageAnnotationsLoader._find_parent_sites("B",
+            fake_lineage_constellation, LineageAnnotationsLoader._create_constellation_pango_mapping(fake_lineage_constellation))
+        self.assertIsNotNone(b_sites)
+        self.assertEqual(len(b_sites), 4)
+

--- a/covigator/tests/unit_tests/test_lineage_annotation.py
+++ b/covigator/tests/unit_tests/test_lineage_annotation.py
@@ -43,10 +43,14 @@ class LineageAnnotationTest(AbstractTest):
         normal_deletion = {"genomic_position": 21990, "length": 3}
         # 21990:TTTATTACCA>T = p.Y144_H146del
         normal_deletion_long = {"genomic_position": 21990, "length": 9}
+        # 22029:AGTTCAG>A = p.F157_R158del
+        normal_deletion_long_2 = {"genomic_position": 22029, "length": 6}
         # 21992:TA>T = p.Y144fs
         fs_deletion = {"genomic_position": 21992, "length": 2}
         # 21992:TATTACCACAAAAACAACAAAAGTTGGATGGAAA>T = p.Y144_S155delinsC
         insdel_deletion = {"genomic_position": 21992, "length": 33}
+        # 21633:TACCCCCTGCATA>T = p.L24_Y28delinsF
+        insdel_deletion_2 = {"genomic_position": 21633, "length": 12}
 
         self.assertEqual(
             self.loader.get_hgvs_from_nuc_deletion(normal_deletion),
@@ -57,12 +61,20 @@ class LineageAnnotationTest(AbstractTest):
             {'hgvs_p': 'p.Y144_H146del', 'reference': 'YYH', 'alternate': 'del', 'position': 144}
         )
         self.assertEqual(
+            self.loader.get_hgvs_from_nuc_deletion(normal_deletion_long_2),
+            {'hgvs_p': 'p.F157_R158del', 'reference': 'FR', 'alternate': 'del', 'position': 157}
+        )
+        self.assertEqual(
             self.loader.get_hgvs_from_nuc_deletion(fs_deletion),
             {'hgvs_p': 'p.Y144fs', 'reference': 'Y', 'alternate': 'del', 'position': 144}
         )
         self.assertEqual(
             self.loader.get_hgvs_from_nuc_deletion(insdel_deletion),
             {'hgvs_p': 'p.Y144_S155delinsC', 'reference': 'YYHKNNKSWMES', 'alternate': 'del', 'position': 144}
+        )
+        self.assertEqual(
+            self.loader.get_hgvs_from_nuc_deletion(insdel_deletion_2),
+            {'hgvs_p': 'p.L24_Y28delinsF', 'reference': 'LPPAY', 'alternate': 'del', 'position': 24}
         )
 
     def test_parse_mutation_sites(self):
@@ -71,10 +83,18 @@ class LineageAnnotationTest(AbstractTest):
         self.assertIsNotNone(parsed_site)
         self.assertEqual(len(parsed_site), 1)
         self.assertIsInstance(parsed_site[0], dict)
+
+        parsed_site = self.loader._parse_mutation_sites("spike:D614G")
+        self.assertIsNotNone(parsed_site)
+        self.assertEqual(len(parsed_site), 1)
+        self.assertIsInstance(parsed_site[0], dict)
+
         # Test that grouped AA level mutation are split into separate mutations
         parsed_site = self.loader._parse_mutation_sites("n:RG203KR")
         self.assertIsNotNone(parsed_site)
         self.assertEqual(len(parsed_site), 2)
+        self.assertTrue(parsed_site[0]["variant_id"] == "N:R203K")
+        self.assertTrue(parsed_site[1]["variant_id"] == "N:G204R")
 
     def _create_constellation_pango_mapping(self):
         fake_lineage_constellation = {
@@ -97,4 +117,5 @@ class LineageAnnotationTest(AbstractTest):
             fake_lineage_constellation, LineageAnnotationsLoader._create_constellation_pango_mapping(fake_lineage_constellation))
         self.assertIsNotNone(b_sites)
         self.assertEqual(len(b_sites), 4)
+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,5 @@ biopython==1.76
 lz4==3.1.3
 scikit-bio==0.5.6
 ipywidgets==7.6.3
+ipython==8.0-8.12
 parameterized==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ biopython==1.76
 lz4==3.1.3
 scikit-bio==0.5.6
 ipywidgets==7.6.3
-ipython==8.0-8.12
+ipython==8.0
 parameterized==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ biopython==1.76
 lz4==3.1.3
 scikit-bio==0.5.6
 ipywidgets==7.6.3
-ipython==8.0
+ipython==8.12
 parameterized==0.8.1

--- a/scripts/sql/20230508_add_lineage_insertions.sql
+++ b/scripts/sql/20230508_add_lineage_insertions.sql
@@ -1,0 +1,6 @@
+INSERT INTO lineage_defining_variant_on(variant_id, variant_type, protein, position, reference, alternate, ambiguous_alternate, annotation, hgvs, variant_level) VALUES ('S:RD214REPED', 'INSERTION', 'S', '214', 'RD', 'REPED', FALSE, 'missense', 'p.R214_D215insEPE', 'aa');
+INSERT INTO lineage_variant_on(pango_lineage_id, variant_id) VALUES('BA.1', 'S:RD214REPED');
+
+INSERT INTO lineage_defining_variant_on(variant_id, variant_type, protein, position, reference, alternate, ambiguous_alternate, annotation, hgvs, variant_level) VALUES ('28262:G>GAACA', 'INSERTION', NULL, '28262', 'G', 'GAACA', FALSE, 'intergenic', NULL, 'nuc');
+
+INSERT INTO lineage_variant_on(pango_lineage_id, variant_id) VALUES('P.1', '28262:G>GAACA');


### PR DESCRIPTION
With this merge request, we include the mutations in the DB that are described to define a given lineage. 
This addresses #62. Since the constellation mutation representation allows descriptions at the nucleotide and amino acid level, we translate SNVs and deletions to the protein level to obtain an HGVS representation in the database
