### PR TITLE
107 remove effect column recurrent mutation table

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,8 @@ The project was kindly supported by
 
 ## How to cite
 
-*   Bukur, T., Riesgo-Ferreiro, P., Sorn, P., Gudimella, R., Hausmann, J., Rösler, T., Löwer, M., Schrörs, B., & Sahin, U. 
-CoVigator – a Knowledge Base for Navigating SARS-CoV-2 Genomic Variants. Preprints.org 2023, 2023060010. 
-[10.20944/preprints202306.0010.v1](https://doi.org/10.20944/preprints202306.0010.v1)
+*   Bukur T., Riesgo-Ferreiro P., Sorn P, Gudimella R., Hausmann J., Rösler T., Löwer M., Schrörs B., & Sahin U. 
+CoVigator — A Knowledge Base for Navigating SARS-CoV-2 Genomic Variants. Viruses. 2023; 15(6):1391. [10.3390/v15061391](https://doi.org/10.3390/v15061391)
 
 *   Schrörs, B., Riesgo-Ferreiro, P., Sorn, P., Gudimella, R., Bukur, T., Rösler, T., Löwer, M., & Sahin, U. (2021). 
 Large-scale analysis of SARS-CoV-2 spike-glycoprotein mutants demonstrates the need for continuous screening of virus 

--- a/covigator/dashboard/figures/figures.py
+++ b/covigator/dashboard/figures/figures.py
@@ -20,7 +20,8 @@ STYLE_HEADER = {
 }
 STYLE_CELL = {
     'padding': '5px',
-    'maxWidth': '100px'
+    'maxWidth': '100px',
+    'whiteSpace': 'normal'
 }
 
 

--- a/covigator/dashboard/figures/intrahost_mutations.py
+++ b/covigator/dashboard/figures/intrahost_mutations.py
@@ -170,8 +170,6 @@ class IntrahostMutationsFigures(Figures):
         logger.debug("Getting data on top occurring intrahost mutations...")
         data = SubclonalVariantsQueries(session=self.queries.session).get_top_occurring_subclonal_variants(
             top=top, gene_name=gene_name, domain=domain, min_vaf=min_vaf, order_by=order_by)
-        lineage_mutation_aa, lineage_mutation_nuc = self.queries.get_lineage_defining_variants()
-        lineage_mutation_nuc.rename(columns={'dna_mutation': 'variant_id'}, inplace=True)
         fig = dcc.Markdown("""**No intrahost variants for the current selection**""")
         if data is not None and data.shape[0] > 0:
             logger.debug("Preparing plot on top occurring intrahost variants...")

--- a/covigator/dashboard/figures/intrahost_mutations.py
+++ b/covigator/dashboard/figures/intrahost_mutations.py
@@ -201,14 +201,8 @@ class IntrahostMutationsFigures(Figures):
 
             unique_subclonal_variants.reset_index(inplace=True)
 
-            # Merge with nulceotide and amino acid level mutations
+            # Merge with llineage defining mutations
             unique_subclonal_variants = self.queries._merge_with_lineage_defining_variants(unique_subclonal_variants)
-            #unique_subclonal_variants = unique_subclonal_variants.merge(lineage_mutation_aa, how="left", left_on="hgvs_p", right_on="hgvs_p")
-            #unique_subclonal_variants = unique_subclonal_variants.merge(lineage_mutation_nuc, how="left", left_on="variant_id", right_on="variant_id")
-            # Create hover label if mutation part of more than three lineages
-            #unique_subclonal_variants['pangolin_hover'] = unique_subclonal_variants.apply(
-            #    lambda x: "{} lineages".format(x.no_of_lineages) if x.no_of_lineages > 3 else x.pangolin_lineage,
-            #        axis=1)
 
             if order_by == "score":
                 ordered_data = unique_subclonal_variants.sort_values("score", ascending=True)

--- a/covigator/dashboard/figures/intrahost_mutations.py
+++ b/covigator/dashboard/figures/intrahost_mutations.py
@@ -202,19 +202,13 @@ class IntrahostMutationsFigures(Figures):
             unique_subclonal_variants.reset_index(inplace=True)
 
             # Merge with nulceotide and amino acid level mutations
-            unique_subclonal_variants = unique_subclonal_variants.merge(lineage_mutation_aa, how="left", left_on="hgvs_p", right_on="hgvs_p")
-            unique_subclonal_variants = unique_subclonal_variants.merge(lineage_mutation_nuc, how="left", left_on="variant_id", right_on="variant_id")
-            # Rename and drop unnecessary columns
-            unique_subclonal_variants["pangolin_lineage_x"].fillna(unique_subclonal_variants["pangolin_lineage_y"], inplace=True)
-            unique_subclonal_variants.drop(columns=["pangolin_lineage_y"])
-            unique_subclonal_variants.rename(columns={"pangolin_lineage_x": "pangolin_lineage"}, inplace=True)
-            # Count lineages containing variant to create hover label
-            unique_subclonal_variants["no_of_lineages"] = unique_subclonal_variants.fillna({"pangolin_lineage": ""}).apply(
-                lambda x: len(x.pangolin_lineage.split(",")), axis=1)
+            unique_subclonal_variants = self.queries._merge_with_lineage_defining_variants(unique_subclonal_variants)
+            #unique_subclonal_variants = unique_subclonal_variants.merge(lineage_mutation_aa, how="left", left_on="hgvs_p", right_on="hgvs_p")
+            #unique_subclonal_variants = unique_subclonal_variants.merge(lineage_mutation_nuc, how="left", left_on="variant_id", right_on="variant_id")
             # Create hover label if mutation part of more than three lineages
-            unique_subclonal_variants['pangolin_hover'] = unique_subclonal_variants.apply(
-                lambda x: "{} lineages".format(x.no_of_lineages) if x.no_of_lineages > 3 else x.pangolin_lineage,
-                    axis=1)
+            #unique_subclonal_variants['pangolin_hover'] = unique_subclonal_variants.apply(
+            #    lambda x: "{} lineages".format(x.no_of_lineages) if x.no_of_lineages > 3 else x.pangolin_lineage,
+            #        axis=1)
 
             if order_by == "score":
                 ordered_data = unique_subclonal_variants.sort_values("score", ascending=True)

--- a/covigator/dashboard/figures/recurrent_mutations.py
+++ b/covigator/dashboard/figures/recurrent_mutations.py
@@ -245,6 +245,11 @@ class RecurrentMutationsFigures(Figures):
 
     def get_top_occurring_variants_plot(self, top, gene_name, domain, date_range_start, date_range_end, metric, source):
         data = self.queries.get_top_occurring_variants_precomputed(top, gene_name, domain, metric, source)
+        lineage_mutations = self.queries.get_lineage_defining_variants()
+        aa_level_mutations = lineage_mutations[~pd.isnull(lineage_mutations.hgvs_p)]
+        nucleotide_level_mutations = lineage_mutations[~pd.isnull(lineage_mutations.dna_mutation)]
+        data = data.merge(aa_level_mutations, how="left", left_on="hgvs_p", right_on="hgvs_p")
+        data = data.merge(nucleotide_level_mutations, how="left", left_on="dna_mutation", right_on="dna_mutation")
 
         fig = [
             dash_table.DataTable(id="top-occurring-variants-table"),
@@ -275,7 +280,7 @@ class RecurrentMutationsFigures(Figures):
                                 {"name": ["Variant", "Gene"], "id": "gene_name"},
                                 {"name": ["", "DNA mutation"], "id": "dna_mutation"},
                                 {"name": ["", "Protein mutation"], "id": "hgvs_p"},
-                                # {"name": ["", "Effect"], "id": "annotation"},
+                                {"name": ["", "Pangolin lineage"], "id": "pangolin_lineage"},
                                 {"name": ["", "Frequency"], "id": "frequency"},
                                 {"name": ["", "Count"], "id": "total"},
                             ] + month_columns,

--- a/covigator/dashboard/figures/recurrent_mutations.py
+++ b/covigator/dashboard/figures/recurrent_mutations.py
@@ -275,7 +275,7 @@ class RecurrentMutationsFigures(Figures):
                                 {"name": ["Variant", "Gene"], "id": "gene_name"},
                                 {"name": ["", "DNA mutation"], "id": "dna_mutation"},
                                 {"name": ["", "Protein mutation"], "id": "hgvs_p"},
-                                {"name": ["", "Effect"], "id": "annotation"},
+                                # {"name": ["", "Effect"], "id": "annotation"},
                                 {"name": ["", "Frequency"], "id": "frequency"},
                                 {"name": ["", "Count"], "id": "total"},
                             ] + month_columns,

--- a/covigator/dashboard/figures/recurrent_mutations.py
+++ b/covigator/dashboard/figures/recurrent_mutations.py
@@ -258,11 +258,6 @@ class RecurrentMutationsFigures(Figures):
             excluded_month_colums = [c for c in month_columns if c < date_range_start or c > date_range_end]
             data.drop(excluded_month_colums, axis=1, inplace=True)
 
-            # Generate hover text for lineage column
-            data["pangolin_hover"] = data.apply(
-                lambda x: "{} lineages".format(x.no_of_lineages) if x.no_of_lineages > 3 else x.pangolin_lineage,
-                    axis=1)
-
             # set the styles of the cells
             styles_counts = discrete_background_color_bins(data, columns=included_month_colums)
             styles_total_count = discrete_background_color_bins(data, columns=["total"], colors="Reds")

--- a/covigator/dashboard/tabs/acknowledgements.py
+++ b/covigator/dashboard/tabs/acknowledgements.py
@@ -20,13 +20,13 @@ def get_tab_acknowledgements():
                 html.P("If you want to cite us:"),
                 html.P([
                     "Bukur, T., Riesgo-Ferreiro, P., Sorn, P., Gudimella, R., Hausmann, J., Rösler, T., "
-                    "Löwer, M., Schrörs, B., & Sahin, U. CoVigator – a Knowledge Base for Navigating SARS-CoV-2 Genomic Variants. "
-                    "Preprints.org 2023, 2023060010.",
+                    "Löwer, M., Schrörs, B., & Sahin, U. CoVigator — A Knowledge Base for Navigating SARS-CoV-2 Genomic Variants. "
+                    "Viruses. 2023; 15(6):1391.",
                 ],
                     style={"font-style": "italic", "margin-left": "50px"}),
                 html.P(
-                    html.A("https://doi.org/10.20944/preprints202306.0010.v1",
-                           href="https://doi.org/10.20944/preprints202306.0010.v1", target="_blank"),
+                    html.A("https://doi.org/10.3390/v15061391",
+                           href="https://doi.org/10.3390/v15061391", target="_blank"),
                     style={"text-indent": "50px"}
                 ),
                 html.P([

--- a/covigator/database/queries.py
+++ b/covigator/database/queries.py
@@ -174,8 +174,8 @@ class Queries:
         Merge tables from recurrent and intrahost mutations tab with lineage defining mutations
         """
         
-        assert "variant_id" in data.columns
-        assert "hgvs_p" in data.columns
+        assert "variant_id" in data.columns, "Column variant_id is missing..."
+        assert "hgvs_p" in data.columns, "Column hgvs_p is missing..."
         lineage_mutation_aa, lineage_mutation_nuc = self.get_lineage_defining_variants()
         lineage_mutation_nuc.rename(columns={'dna_mutation': 'variant_id'}, inplace=True)
 
@@ -640,17 +640,10 @@ class Queries:
             query = query.order_by(PrecomputedOccurrence.frequency.desc())
         else:
             raise CovigatorQueryException("Not supported metric for top occurring variants")
-
-        #lineage_mutation_aa, lineage_mutation_nuc = self.get_lineage_defining_variants()
-        #lineage_mutation_nuc.rename(columns={'dna_mutation': 'variant_id'}, inplace=True)
         
         top_occurring_variants = pd.read_sql(query.statement, self.session.bind)
+        # Merge with lineage defining variants
         top_occurring_variants = self._merge_with_lineage_defining_variants(top_occurring_variants)
-        #top_occurring_variants = top_occurring_variants.merge(lineage_mutation_aa, how="left", left_on="hgvs_p", right_on="hgvs_p")
-        #top_occurring_variants = top_occurring_variants.merge(lineage_mutation_nuc, how="left", left_on="variant_id", right_on="variant_id")
-        # Fill up lineage information for integenic variants
-        #top_occurring_variants["pangolin_lineage_x"].fillna(top_occurring_variants["pangolin_lineage_y"], inplace=True)
-        #top_occurring_variants.drop(columns=["pangolin_lineage_y"])
         # formats the DNA mutation
         top_occurring_variants.rename(columns={"variant_id": "dna_mutation"}, inplace=True)
 

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -251,7 +251,7 @@ class QueriesTests(AbstractTest):
         self.assertIsNotNone(merged_table)
         self.assertGreater(merged_table.shape[0], 0)
         # All mutations overlap with lineage mutations
-        self.assertEqual(merged_table[merged_table.no_of_lineages.isna()], 0)
+        self.assertEqual(merged_table[merged_table.no_of_lineages.isna()].shape[0], 0)
         # Correct lineage numbers returned
         self.assertTrue(merged_table.no_of_lineages.values.tolist() == [21, 19, 20, 2])
         # Check that hover label is created correctly

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -243,6 +243,21 @@ class QueriesTests(AbstractTest):
         self.assertTrue("dna_mutation" in lineage_mutation_nuc.columns)
         self.assertTrue("hgvs_p" in lineage_mutation_aa.columns)
 
+    def test_merge_with_lineage_defining_variants(self):
+        import pandas as pd
+        data = {"variant_id": ["23403:A>G", "10029:C>T", "22995:C>A", "11201:A>G"], "hgvs_p": ["p.D614G", "p.T3255I", "p.T478K", "p.T3646A"]}
+        df = pd.DataFrame(data=data)
+        merged_table = self.queries._merge_with_lineage_defining_variants(df)
+        self.assertIsNotNone(merged_table)
+        self.assertGreater(merged_table.shape[0], 0)
+        # All mutations overlap with lineage mutations
+        self.assertEqual(merged_table[merged_table.no_of_samples.isna()], 0)
+        # Correct lineage numbers returned
+        self.assertTrue(merged_table.no_of_samples.values.tolist() == [21, 19, 20, 2])
+        # Check that hover label is created correctly
+        self.assertTrue(merged_table.no_of_samples.pangolin_hover.tolist() == ["21 lineages", "19 lineages", "20 lineages", "AY.4,AY.4.2"])
+
+
     def test_count_jobs_in_queue(self):
         mock_samples(faker=self.faker, session=self.session, job_status=JobStatus.QUEUED, num_samples=50)
         mock_samples(faker=self.faker, session=self.session, job_status=JobStatus.FINISHED, num_samples=50)

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -253,9 +253,9 @@ class QueriesTests(AbstractTest):
         # All mutations overlap with lineage mutations
         self.assertEqual(merged_table[merged_table.no_of_lineages.isna()], 0)
         # Correct lineage numbers returned
-        self.assertTrue(merged_table.no_of_samples.values.tolist() == [21, 19, 20, 2])
+        self.assertTrue(merged_table.no_of_lineages.values.tolist() == [21, 19, 20, 2])
         # Check that hover label is created correctly
-        self.assertTrue(merged_table.no_of_samples.pangolin_hover.tolist() == ["21 lineages", "19 lineages", "20 lineages", "AY.4,AY.4.2"])
+        self.assertTrue(merged_table.pangolin_hover.tolist() == ["21 lineages", "19 lineages", "20 lineages", "AY.4,AY.4.2"])
 
 
     def test_count_jobs_in_queue(self):

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -232,6 +232,17 @@ class QueriesTests(AbstractTest):
         self.assertGreater(labels.shape[0], 0)
         self.assertEqual(labels[labels.combined_label.isna()].shape[0], 0)
 
+    def test_get_lineage_defining_variants(self):
+        lineage_mutation_aa, lineage_mutation_nuc = self.queries.get_lineage_defining_variants()
+        self.assertIsNotNone(lineage_mutation_aa)
+        self.assertIsNotNone(lineage_mutation_nuc)
+        self.assertGreater(lineage_mutation_aa.shape[0], 0)
+        self.assertGreater(lineage_mutation_nuc.shape[0], 0)
+
+        # Make sure that mutations on different levels have different columns for merging
+        self.assertTrue("dna_mutation" in lineage_mutation_nuc.columns)
+        self.assertTrue("hgvs_p" in lineage_mutation_aa.columns)
+
     def test_count_jobs_in_queue(self):
         mock_samples(faker=self.faker, session=self.session, job_status=JobStatus.QUEUED, num_samples=50)
         mock_samples(faker=self.faker, session=self.session, job_status=JobStatus.FINISHED, num_samples=50)

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -255,7 +255,7 @@ class QueriesTests(AbstractTest):
         # Correct lineage numbers returned
         self.assertTrue(merged_table.no_of_lineages.values.tolist() == [21, 19, 20, 2])
         # Check that hover label is created correctly
-        self.assertTrue(merged_table.pangolin_hover.tolist() == ["21 lineages", "19 lineages", "20 lineages", "AY.4,AY.4.2"])
+        self.assertTrue(merged_table.pangolin_hover.values.tolist() == ["21 lineages", "19 lineages", "20 lineages", "AY.4,AY.4.2"])
 
 
     def test_count_jobs_in_queue(self):

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -251,7 +251,7 @@ class QueriesTests(AbstractTest):
         self.assertIsNotNone(merged_table)
         self.assertGreater(merged_table.shape[0], 0)
         # All mutations overlap with lineage mutations
-        self.assertEqual(merged_table[merged_table.no_of_samples.isna()], 0)
+        self.assertEqual(merged_table[merged_table.no_of_lineages.isna()], 0)
         # Correct lineage numbers returned
         self.assertTrue(merged_table.no_of_samples.values.tolist() == [21, 19, 20, 2])
         # Check that hover label is created correctly

--- a/covigator/tests/unit_tests/test_queries.py
+++ b/covigator/tests/unit_tests/test_queries.py
@@ -255,7 +255,7 @@ class QueriesTests(AbstractTest):
         # Correct lineage numbers returned
         self.assertTrue(merged_table.no_of_lineages.values.tolist() == [21, 19, 20, 2])
         # Check that hover label is created correctly
-        self.assertTrue(merged_table.pangolin_hover.values.tolist() == ["21 lineages", "19 lineages", "20 lineages", "AY.4,AY.4.2"])
+        self.assertTrue(merged_table.pangolin_hover.values.tolist() == ["21 lineages", "19 lineages", "20 lineages", "AY.4.2,AY.4"])
 
 
     def test_count_jobs_in_queue(self):

--- a/docs/source/01_overview.md
+++ b/docs/source/01_overview.md
@@ -68,8 +68,8 @@ The project was kindly supported by
 ## How to cite
 
 * Bukur, T., Riesgo-Ferreiro, P., Sorn, P., Gudimella, R., Hausmann, J., Rösler, T., Löwer, M., Schrörs, B., & Sahin, U. 
-  CoVigator – a Knowledge Base for Navigating SARS-CoV-2 Genomic Variants. Preprints.org 2023, 2023060010. 
-  [10.20944/preprints202306.0010.v1](https://doi.org/10.20944/preprints202306.0010.v1)
+  CoVigator — A Knowledge Base for Navigating SARS-CoV-2 Genomic Variants. Viruses. 2023; 15(6):1391. 
+  [10.3390/v15061391](https://doi.org/10.3390/v15061391)
 
 * Schrörs, B., Riesgo-Ferreiro, P., Sorn, P., Gudimella, R., Bukur, T., Rösler, T., Löwer, M., & Sahin, U. (2021). 
   Large-scale analysis of SARS-CoV-2 spike-glycoprotein mutants demonstrates the need for continuous screening of virus 


### PR DESCRIPTION
* Removed effect column from recurrent mutation table, closes #107
* Added overlap with lineage defining mutations in recurrent & intrahost mutation tab 
* Updated citations in README, Read the docs and the acknowledgements_tab