### PR TITLE
104 update ena accessor nanopore

### DIFF
--- a/covigator/accessor/ena_accessor.py
+++ b/covigator/accessor/ena_accessor.py
@@ -192,7 +192,7 @@ class EnaAccessor(AbstractAccessor):
             self.excluded_samples_by_fastq_ftp += 1
         instrument_platform = ena_run.get("instrument_platform")
         # Include Illumina and Nanopore samples
-        if instrument_platform.upper() != "ILLUMINA" and instrument_platform.upper() != "OXFORD_NANOPORE":
+        if instrument_platform.upper() not in ["ILLUMINA", "OXFORD_NANOPORE"]:
             included = False    # skips non Illumina and Nanopore data
             self.excluded_samples_by_instrument_platform[str(instrument_platform)] = \
                 self.excluded_samples_by_instrument_platform.get(str(instrument_platform), 0) + 1

--- a/covigator/accessor/ena_accessor.py
+++ b/covigator/accessor/ena_accessor.py
@@ -66,7 +66,7 @@ class EnaAccessor(AbstractAccessor):
         "WGS",
         "Targeted-Capture"
     ]
-    ONT_INCLUDED_LIBRARY_STRATEGIES = INCLUDED_LIBRARY_STRATEGIES.append("AMPLICON")
+    ONT_INCLUDED_LIBRARY_STRATEGIES = INCLUDED_LIBRARY_STRATEGIES + ["AMPLICON"]
 
     def __init__(self, tax_id: str, host_tax_id: str, database: Database, maximum=None):
 


### PR DESCRIPTION
In order to support the Nanopore workflow in the covigator NGS-pipeline we need to stop excluding Oxford Nanopore Sample in the ENA accessor. This pull request adds support for this feature.