### PR TITLE
Update dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ m2r2==0.3.1
 nbsphinx==0.8.7
 pandoc==1.1.0
 ipython==8.10.0
-ipykernel==6.4.1
+ipykernel==6.26.0
 #sphinx_rtd_theme==0.5.0
 #insipid_sphinx_theme==0.2.1
 pydata-sphinx-theme==0.7.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ Sphinx==4.2.0
 m2r2==0.3.1
 nbsphinx==0.8.7
 pandoc==1.1.0
-ipython==7.31.1
+ipython==8.10.0
 ipykernel==6.4.1
 #sphinx_rtd_theme==0.5.0
 #insipid_sphinx_theme==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 numpy==1.22.0
 pandas==1.3.3
-requests==2.25.0
+requests==2.31.0
 sqlalchemy==1.3.20
 dask[complete]==2022.9.2
 dask_jobqueue==0.8.1
 distributed==2022.9.2
-Werkzeug==2.0.1
+Werkzeug==2.2.3
 cytoolz==0.11.0
 logzero==1.6.3
 psycopg2-binary==2.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ sqlalchemy==1.3.20
 dask[complete]==2022.9.2
 dask_jobqueue==0.8.1
 distributed==2022.9.2
-Werkzeug==2.2.3
+Werkzeug==2.3.8
 cytoolz==0.11.0
 logzero==1.6.3
 psycopg2-binary==2.8.6


### PR DESCRIPTION
Closes #97 
Closes #99 
Bumps request from 2.25.0 to 2.31.0

These updates should fix all security issues currently reported by dependabot